### PR TITLE
Add Content-Type to CldUploadWidget Signature Headers

### DIFF
--- a/docs/pages/api/sign-cloudinary-params.js
+++ b/docs/pages/api/sign-cloudinary-params.js
@@ -1,8 +1,7 @@
 import { v2 as cloudinary } from "cloudinary";
 
 export default async function handler(req, res) {
-  const body = JSON.parse(req.body) || {};
-  const { paramsToSign } = body;
+  const { paramsToSign } = req.body;
 
   try {
     const signature = cloudinary.utils.api_sign_request(

--- a/docs/pages/clduploadwidget/signed-uploads.mdx
+++ b/docs/pages/clduploadwidget/signed-uploads.mdx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { Tab, Tabs } from 'nextra-theme-docs';
+import { Tab, Tabs, Callout } from 'nextra-theme-docs';
 
 import OgImage from '../../components/OgImage';
 import CodeBlock from '../../components/CodeBlock';
@@ -98,6 +98,11 @@ the App Router or Pages router.
     **In the Pages Router**, create a new API endpoint file such as `pages/api/sign-cloudinary-params.js`, where
     inside, add the folowing code:
 
+    <Callout emoji={false} type="warning">
+      If using Next Cloudinary v5 or lower, you need to use `JSON.parse(req.body)` to obtain the JSON payload
+      of the Signature Request from the Upload Widget.
+    </Callout>
+
     <CodeBlock>
       ```jsx copy showLineNumbers
       import { v2 as cloudinary } from "cloudinary";
@@ -109,8 +114,7 @@ the App Router or Pages router.
       });
 
       export default async function handler(req, res) {
-        const body = JSON.parse(req.body) || {};
-        const { paramsToSign } = body;
+        const { paramsToSign } = req.body;
 
         const signature = cloudinary.utils.api_sign_request(paramsToSign, process.env.CLOUDINARY_API_SECRET);
 

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -150,6 +150,9 @@ const CldUploadWidget = ({
       body: JSON.stringify({
         paramsToSign,
       }),
+      headers: {
+        'Content-Type': 'application/json'
+      }
     })
       .then((r) => r.json())
       .then(({ signature }) => {


### PR DESCRIPTION
# Description

The CldUploadWidget makes a request to an API endpoint when signing requests and currently doesn't pass along any headers such as Content-Type.

This explicitly defines them as the payload as `application/json`.

https://github.com/cloudinary-community/next-cloudinary/issues/379

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
