### PR TITLE
CldUploadWidget Events Normalization

### DIFF
--- a/docs/pages/clduploadwidget/configuration.mdx
+++ b/docs/pages/clduploadwidget/configuration.mdx
@@ -150,7 +150,7 @@ uploadPreset="my-upload-preset"
     {
       prop: 'onClose',
       type: 'function',
-      example: () => (<code>{`(widget) => { }`}</code>),
+      example: () => (<code>{`(results, options) => { }`}</code>),
       more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#close_event">More Info</a>)
     },
     {
@@ -162,7 +162,7 @@ uploadPreset="my-upload-preset"
     {
       prop: 'onError',
       type: 'function',
-      example: () => (<code>{`(error, widget) => { }`}</code>),
+      example: () => (<code>{`(error, options) => { }`}</code>),
     },
     {
       prop: 'onOpen',
@@ -218,7 +218,7 @@ uploadPreset="my-upload-preset"
       more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#tags">More Info</a>)
     },
     {
-      prop: 'onUpload',
+      prop: 'onUpload (Deprecated)',
       type: 'function',
       example: () => (<code>{`(results, widget) => { }`}</code>),
     },

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -23,7 +23,6 @@ import {checkForCloudName} from "../../lib/cloudinary";
 
 const WIDGET_WATCHED_EVENTS = [
   'success',
-  'display-changed'
 ];
 
 const WIDGET_EVENTS: { [key: string]: string } = {

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -12,10 +12,13 @@ export interface CldUploadWidgetProps {
   children?: ({ cloudinary, widget, open, results, error }: CldUploadWidgetPropsChildren) => JSX.Element;
   onError?: CldUploadEventCallbackError;
   onOpen?: CldUploadEventCallbackWidgetOnly;
+  /**
+   * @deprecated use onSuccess instead
+   */
   onUpload?: CldUploadEventCallbackNoOptions;
   onAbort?: CldUploadEventCallback;
   onBatchCancelled?: CldUploadEventCallback;
-  onClose?: CldUploadEventCallbackWidgetOnly;
+  onClose?: CldUploadEventCallback;
   onDisplayChanged?: CldUploadEventCallback;
   onPublicId?: CldUploadEventCallback;
   onQueuesEnd?: CldUploadEventCallback;
@@ -34,7 +37,6 @@ export interface CldUploadWidgetProps {
 export type CldUploadWidgetPropsChildren = {
   cloudinary: CldUploadWidgetCloudinaryInstance;
   widget: CldUploadWidgetWidgetInstance;
-
   error?: CloudinaryUploadWidgetError;
   isLoading?: boolean;
   results?: CloudinaryUploadWidgetResults;
@@ -43,7 +45,7 @@ export type CldUploadWidgetPropsChildren = {
 export type CldUploadEventCallback = (results: CloudinaryUploadWidgetResults, widget: CldUploadEventCallbackWidget) => void;
 export type CldUploadEventCallbackNoOptions = (results: CloudinaryUploadWidgetResults, widget: CldUploadWidgetWidgetInstance) => void;
 export type CldUploadEventCallbackWidgetOnly = (widget: CldUploadWidgetWidgetInstance) => void;
-export type CldUploadEventCallbackError = (error: CloudinaryUploadWidgetError, widget: CldUploadWidgetWidgetInstance) => void;
+export type CldUploadEventCallbackError = (error: CloudinaryUploadWidgetError, widget: CldUploadEventCallbackWidget) => void;
 
 export type CldUploadEventCallbackWidget = {
   widget: CldUploadWidgetWidgetInstance;


### PR DESCRIPTION
# Description

* Updates the onError and onClose signatures to match other callback methods
* Deprecates onUpload in favor of onSuccess, matching the native Cloudinary Upload Widget API