### PR TITLE
Remove Default 2-Stage Image Sizing

### DIFF
--- a/docs/components/CodeBlock/CodeBlock.js
+++ b/docs/components/CodeBlock/CodeBlock.js
@@ -1,13 +1,15 @@
 import { useState } from 'react';
 import { BsArrowsExpand, BsArrowsCollapse } from 'react-icons/bs'
 
+import { cn } from '../../lib/utils';
+
 import styles from './CodeBlock.module.scss';
 
-export const CodeBlock = ({ children }) => {
+export const CodeBlock = ({ children, className }) => {
   const [expanded, setExpanded] = useState(false);
   
   return (
-    <div className={styles.codeBlock}>
+    <div className={cn(styles.codeBlock, className)}>
       <div className={styles.codeBlockCode} data-codeblock-expanded={expanded}>
         { children }
       </div>

--- a/docs/components/CodeBlock/CodeBlock.module.scss
+++ b/docs/components/CodeBlock/CodeBlock.module.scss
@@ -1,6 +1,5 @@
 .codeBlock {
   position: relative;
-  margin: 1.5em 0;
 }
 
 .codeBlockCode {

--- a/docs/components/ExamplesCldOgImage/ExamplesCldOgImage.js
+++ b/docs/components/ExamplesCldOgImage/ExamplesCldOgImage.js
@@ -9,7 +9,7 @@ const ExamplesCldOgImage = ({ ...props }) => {
       crop={{
         width: OG_IMAGE_WIDTH,
         height: OG_IMAGE_HEIGHT,
-        crop: 'fill',
+        type: 'fill',
         gravity: 'center',
         source: true
       }}

--- a/docs/components/ExamplesCldOgImage/ExamplesCldOgImage.js
+++ b/docs/components/ExamplesCldOgImage/ExamplesCldOgImage.js
@@ -1,0 +1,20 @@
+import { CldImage } from '../../../next-cloudinary/dist';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../../next-cloudinary/src/constants/sizes';
+
+const ExamplesCldOgImage = ({ ...props }) => {
+  return (
+    <CldImage
+      width={OG_IMAGE_WIDTH}
+      height={OG_IMAGE_HEIGHT}
+      baseCrop="fill"
+      baseGravity="center"
+      baseHeight={OG_IMAGE_HEIGHT}
+      baseWidth={OG_IMAGE_WIDTH}
+      sizes="100vw"
+      alt=""
+      {...props}
+    />
+  )
+}
+
+export default ExamplesCldOgImage;

--- a/docs/components/ExamplesCldOgImage/ExamplesCldOgImage.js
+++ b/docs/components/ExamplesCldOgImage/ExamplesCldOgImage.js
@@ -6,10 +6,13 @@ const ExamplesCldOgImage = ({ ...props }) => {
     <CldImage
       width={OG_IMAGE_WIDTH}
       height={OG_IMAGE_HEIGHT}
-      baseCrop="fill"
-      baseGravity="center"
-      baseHeight={OG_IMAGE_HEIGHT}
-      baseWidth={OG_IMAGE_WIDTH}
+      crop={{
+        width: OG_IMAGE_WIDTH,
+        height: OG_IMAGE_HEIGHT,
+        crop: 'fill',
+        gravity: 'center',
+        source: true
+      }}
       sizes="100vw"
       alt=""
       {...props}

--- a/docs/components/ExamplesCldOgImage/index.js
+++ b/docs/components/ExamplesCldOgImage/index.js
@@ -1,0 +1,1 @@
+export { default } from './ExamplesCldOgImage';

--- a/docs/lib/utils.js
+++ b/docs/lib/utils.js
@@ -1,0 +1,7 @@
+import {clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs))
+}
+

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,22 +11,22 @@
   "dependencies": {
     "@cloudinary-util/url-loader": "4.2.0",
     "@cloudinary-util/util": "^3.0.0",
-    "@vercel/analytics": "^1.0.1",
-    "cloudinary": "^1.37.3",
+    "@vercel/analytics": "^1.2.2",
+    "cloudinary": "^2.0.1",
     "clsx": "^2.1.0",
-    "next": "^14.0.0",
+    "next": "^14.1.0",
     "nextjs-google-analytics": "^2.3.3",
-    "nextra": "^2.13.2",
-    "nextra-theme-docs": "^2.13.2",
+    "nextra": "^2.13.3",
+    "nextra-theme-docs": "^2.13.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.11.0",
-    "sass": "^1.63.6",
+    "react-icons": "^5.0.1",
+    "sass": "^1.71.1",
     "tailwind-merge": "^2.2.1"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.16",
-    "postcss": "^8.4.31",
-    "tailwindcss": "^3.3.5"
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "@cloudinary-util/util": "^3.0.0",
     "@vercel/analytics": "^1.0.1",
     "cloudinary": "^1.37.3",
+    "clsx": "^2.1.0",
     "next": "^14.0.0",
     "nextjs-google-analytics": "^2.3.3",
     "nextra": "^2.13.2",
@@ -20,7 +21,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
-    "sass": "^1.63.6"
+    "sass": "^1.63.6",
+    "tailwind-merge": "^2.2.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",

--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -18,6 +18,12 @@
       "breadcrumb": false
     }
   },
+  "changelog": {
+    "title": "Changelog",
+    "theme": {
+      "breadcrumb": false
+    }
+  },
   "Components": {
     "type": "separator",
     "title": "Components"

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -35,7 +35,9 @@ This is a fundamental change in how the API works
 </Callout>
 
 * Removes default 2-stage resizing to avoid low resolution images for larger source images  ([#431](https://github.com/cloudinary-community/next-cloudinary/pull/431))
-  * See RFC for more context: https://github.com/cloudinary-community/next-cloudinary/discussions/432
+  * Learn more about [cropping](/cldimage/configuration#crop)
+  * Learn more about [responsive images](/guides/responsive-images)
+  * See the RFC with more details behind the change: https://github.com/cloudinary-community/next-cloudinary/discussions/432
 
 **CldImage**
 * Deprecates `transformations` in favor of `namedTransformations`

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -1,0 +1,57 @@
+import Head from 'next/head';
+import { Callout, Steps, Tab, Tabs } from 'nextra-theme-docs';
+
+
+import OgImage from '../components/OgImage';
+
+import { CldImage } from '../../next-cloudinary';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../next-cloudinary/src/constants/sizes';
+
+<Head>
+  <title>Installation - Next Cloudinary</title>
+  <meta name="og:title" content="Installing Next Cloudinary - Next Cloudinary" />
+  <meta name="og:url" content={`https://next.cloudinary.dev/installation`} />
+</Head>
+
+<OgImage
+  title="Changelog"
+  twitterTitle="Changelog"
+/>
+
+# Changelog
+
+## v6.0.0
+
+### Overview
+
+### Changes
+
+* Migrates project to pnpm ([#419](https://github.com/cloudinary-community/next-cloudinary/pull/419))
+
+**CldImage, getCldImageUrl, CldOgImage, getCldOgImageUrl**
+
+<Callout emoji={false} type="warning">
+This is a fundamental change in how the API works
+</Callout>
+
+* Removes default 2-stage resizing to avoid low resolution images for larger source images  ([#431](https://github.com/cloudinary-community/next-cloudinary/pull/431))
+  * See RFC for more context: https://github.com/cloudinary-community/next-cloudinary/discussions/432
+
+**CldImage**
+* Deprecates `transformations` in favor of `namedTransformations`
+
+**getCldImageUrl**
+* Removes types GetCldImageUrl and GetCldOgImageUrl
+
+**CldUploadWidget**
+* Add Content-Type to CldUploadWidget signature endpoint ([#379](https://github.com/cloudinary-community/next-cloudinary/issues/379))
+* Deprecates some CldUploadWidget types in favor of natively defined types from [@cloudinary-util/types](https://github.com/colbyfayock/cloudinary-util/tree/main/packages/types)
+  * CldUploadWidgetInfo, CldUploadWidgetPropsOptions, CldUploadWidgetResults
+* Updates onError and onClose callbacks to have a consistent API with the rest of the callbacks ([#424](https://github.com/cloudinary-community/next-cloudinary/pull/424))
+* Deprecates onUpload in favor of onSuccess, matching the native Cloudinary Upload Widget API ([#424](https://github.com/cloudinary-community/next-cloudinary/pull/424))
+
+**CldVideoPlayer**
+* Removes autoPlay in favor of autoplay
+* Video Player: CldVideoPlayerPropsColors
+* Deprecates some CldVideoPlayer types in favor of natively defined types from [@cloudinary-util/types](https://github.com/colbyfayock/cloudinary-util/tree/main/packages/types)
+  * CldVideoPlayerPropsColors

--- a/docs/pages/cldimage/basic-usage.mdx
+++ b/docs/pages/cldimage/basic-usage.mdx
@@ -77,7 +77,7 @@ You can further take advantage of Cloudinary features like background removal an
     src={`${process.env.IMAGES_DIRECTORY}/turtle`}
     crop="fill"
     removeBackground
-    tint="70:blue:green:purple"
+    tint="70:blue:purple"
     underlay={`${process.env.IMAGES_DIRECTORY}/galaxy`}
     sizes="100vw"
     alt="Turtle in the ocean"
@@ -94,7 +94,7 @@ You can further take advantage of Cloudinary features like background removal an
     src="<Public ID>"
     crop="fill"
     removeBackground
-    tint="70:blue:green:purple"
+    tint="70:blue:purple"
     underlay="<Public ID>"
     sizes="100vw"
     alt="Description of my image"
@@ -112,7 +112,7 @@ must include a version number (/v1234) in order to be correctly parsed.
   to ensure the integretiy when during the parsing process.
 </Callout>
 
-<CodeBlock>
+<CodeBlock className="mt-6">
   ```jsx copy showLineNumbers
   import { CldImage } from 'next-cloudinary';
 

--- a/docs/pages/cldimage/configuration.mdx
+++ b/docs/pages/cldimage/configuration.mdx
@@ -135,9 +135,9 @@ right inside of Next.js.
 
     {
       prop: 'crop',
-      type: 'string',
+      type: 'string | object',
       default: () => (<code>limit</code>),
-      example: () => (<code>thumb</code>),
+      example: () => (<code>fill</code>),
       more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#c_crop_resize">More Info</a>)
     },
     {
@@ -222,10 +222,104 @@ background="blue"
 
 Changes the size of the delivered asset according to the requested width & height dimensions.
 
+The `crop` prop can either be a string, which can accept any [valid Cloudinary crop mode](https://cloudinary.com/documentation/transformation_reference#c_crop_resize),
+or it can accept an object or an array of objects which can take the following options:
+
+<Table
+  columns={[
+    {
+      id: 'prop',
+      title: 'Prop'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    }
+  ]}
+  data={[
+    {
+      prop: 'aspectRatio',
+      type: 'string',
+      example: () => (<code>16:9</code>),
+    },
+    {
+      prop: 'gravity',
+      type: 'string',
+      example: () => (<a href="#gravity">See Gravity</a>),
+    },
+    {
+      prop: 'height',
+      type: 'string',
+      example: () => (<a href="#required-props">See Height</a>),
+    },
+    {
+      prop: 'source',
+      type: 'boolean',
+      example: () => (<code>true</code>),
+    },
+    {
+      prop: 'type (crop mode)',
+      type: 'string',
+      example: () => (<code>fill</code>),
+    },
+    {
+      prop: 'width',
+      type: 'string',
+      example: () => (<a href="#required-props">See Width</a>),
+    },
+    {
+      prop: 'zoom',
+      type: 'string',
+      example: () => (<a href="#zoom">See Zoom</a>),
+    },
+  ]}
+/>
+
+**Dynamic Crop Modes**
+
+When using a dynamic crop mode, such as `thumb`, the resulting image may
+be visually different based on the given dimensions. For instance, an
+image cropped using the `thumb` crop mode with dimensions 600x600 will
+give different results than 1200x1200 (assuming a gravity of auto or similar,
+which is the default for CldImage).
+
+This is especially important in the context of [Responsive Images](/guides/responsive-images)
+where due to the resize mechanism, different device sizes may result
+in different looking images, which doesn't provide a great experience.
+
+To resolve this, when using dynamic crop modes you may want to opt into
+a two-stage crop, first cropping the original source image, then allowing
+the the resize mechanism to handle resizing that to the appropriate device
+size. See examples below.
+
+<Callout emoji={false}>
+  Versions 5 and below of Next Cloudinary automatically opted CldImage in
+  to a two-stage cropping to help improve the experience, but it came with
+  drawbacks including prematurely limiting the potential resulting size
+  of an image. [Learn more](https://github.com/cloudinary-community/next-cloudinary/discussions/432).
+</Callout>
+
 **Examples**
+
+Cropping an image and filling the containing space:
 
 ```jsx copy
 crop="fill"
+```
+
+Using a crop of `thumb` on the original source image:
+
+```jsx copy
+crop={{
+  width: 1200,
+  height: 1200,
+  type: 'thumb',
+  source: true
+}}
 ```
 
 [Learn more about the crop transformation](https://cloudinary.com/documentation/transformation_reference#c_crop_resize) on the Cloudinary docs.

--- a/docs/pages/cldimage/examples.mdx
+++ b/docs/pages/cldimage/examples.mdx
@@ -677,10 +677,11 @@ that applies a blend mode, such as "multiply"
         {
           crop: 'fill',
           gravity: 'auto',
-          width: 960,
-          height: 600
+          width: '1.0',
+          height: '1.0',
         }
       ],
+      flags: ['relative'],
       appliedEffects: [
         {
           multiply: true
@@ -706,10 +707,11 @@ that applies a blend mode, such as "multiply"
         {
           crop: 'fill',
           gravity: 'auto',
-          width: 960,
-          height: 600
+          width: '1.0',
+          height: '1.0',
         }
       ],
+      flags: ['relative'],
       appliedEffects: [
         {
           multiply: true
@@ -771,21 +773,23 @@ Image underlays allow you to place one or multiple images behind a base image.
     underlays={[
       {
         publicId: 'images/galaxy',
-        width: 480,
-        height: 600,
+        width: '0.5',
+        height: '1.0',
         crop: 'fill',
         position: {
           gravity: 'north_west'
-        }
+        },
+        flags: ['relative']
       },
       {
         publicId: 'images/mountain',
-        width: 480,
-        height: 600,
+        width: '0.5',
+        height: '1.0',
         crop: 'fill',
         position: {
           gravity: 'south_east'
-        }
+        },
+        flags: ['relative']
       },
     ]}
     alt=""
@@ -804,22 +808,24 @@ Image underlays allow you to place one or multiple images behind a base image.
     removeBackground
     underlays={[
       {
-        publicId: '<Your Public ID>',
-        width: 480,
-        height: 600,
+        publicId: 'images/galaxy',
+        width: '0.5',
+        height: '1.0',
         crop: 'fill',
         position: {
           gravity: 'north_west'
-        }
+        },
+        flags: ['relative']
       },
       {
-        publicId: '<Your Public ID>',
-        width: 480,
-        height: 600,
+        publicId: 'images/mountain',
+        width: '0.5',
+        height: '1.0',
         crop: 'fill',
         position: {
           gravity: 'south_east'
-        }
+        },
+        flags: ['relative']
       },
     ]}
     alt=""
@@ -832,40 +838,6 @@ Image underlays allow you to place one or multiple images behind a base image.
 
 Text overlays allow you to place text on top of an image.
 
-### Adding Text
-
-`text`: Adds text to an image with default settings
-
-<HeaderImage>
-  <CldImage
-    width="1335"
-    height="891"
-    src={`${process.env.IMAGES_DIRECTORY}/galaxy`}
-    sizes="100vw"
-    blur="2000"
-    brightness="300"
-    text="Cool Beans"
-    alt=""
-  />
-</HeaderImage>
-
-<CodeBlock>
-  ```jsx copy showLineNumbers
-  import { CldImage } from 'next-cloudinary';
-
-  <CldImage
-    width="1335"
-    height="891"
-    src="<Your Public ID>"
-    sizes="100vw"
-    blur="2000"
-    brightness="300"
-    text="Cool Beans"
-    alt=""
-  />
-  ```
-</CodeBlock>
-
 ### Adding Custom Text
 
 `overlays`: Uses overlay objects to add text on top of an image.
@@ -877,8 +849,6 @@ Text overlays allow you to place text on top of an image.
     src={`${process.env.IMAGES_DIRECTORY}/sneakers`}
     sizes="100vw"
     overlays={[{
-      width: 2670 - 20,
-      crop: 'fit',
       position: {
         x: 140,
         y: 140,
@@ -888,11 +858,11 @@ Text overlays allow you to place text on top of an image.
       text: {
         color: 'blueviolet',
         fontFamily: 'Source Sans Pro',
-        fontSize: 160,
+        fontSize: 280,
         fontWeight: 'bold',
         textDecoration: 'underline',
         letterSpacing: 14,
-        text: 'Cool Beans'
+        text: 'With Style'
       }
     }]}
     alt=""
@@ -909,8 +879,6 @@ Text overlays allow you to place text on top of an image.
     src="<Your Public ID>"
     sizes="100vw"
     overlays={[{
-      width: 2670 - 20,
-      crop: 'fit',
       position: {
         x: 140,
         y: 140,
@@ -920,7 +888,7 @@ Text overlays allow you to place text on top of an image.
       text: {
         color: 'blueviolet',
         fontFamily: 'Source Sans Pro',
-        fontSize: 160,
+        fontSize: 280,
         fontWeight: 'bold',
         textDecoration: 'underline',
         letterSpacing: 14,
@@ -946,9 +914,9 @@ Text overlays allow you to place text on top of an image.
       text: {
         color: 'white',
         fontFamily: 'Source Sans Pro',
-        fontSize: 160,
+        fontSize: 500,
         fontWeight: 'bold',
-        text: 'Cool Beans'
+        text: 'Into the Galaxy'
       },
       effects: [
         {
@@ -974,9 +942,9 @@ Text overlays allow you to place text on top of an image.
       text: {
         color: 'white',
         fontFamily: 'Source Sans Pro',
-        fontSize: 160,
+        fontSize: 500,
         fontWeight: 'bold',
-        text: 'Cool Beans'
+        text: 'Into the Galaxy'
       },
       effects: [
         {

--- a/docs/pages/cldimage/examples.mdx
+++ b/docs/pages/cldimage/examples.mdx
@@ -140,7 +140,7 @@ position the subject in the center of the resulting image.
     height="300"
     src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
     sizes="100vw"
-    crop="thumb"
+    crop="fill"
     alt=""
   />
 </HeaderImage>
@@ -154,11 +154,60 @@ position the subject in the center of the resulting image.
     height="300"
     src="<Your Public ID>"
     sizes="100vw"
-    crop="thumb"
+    crop="fill"
     alt=""
   />
   ```
 </CodeBlock>
+
+Cloudinary additionally supports dynamic crop modes like `thumb` that
+may provide a different result based on the given width and height. To
+help provide more options for controlling cropping images, you can specify
+and object or array of objects.
+
+For instance, to crop the original source image, which will then later
+resize it to the initial width and height, you can use:
+
+
+<HeaderImage>
+  <CldImage
+    width="300"
+    height="300"
+    src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
+    sizes="100vw"
+    crop={{
+      width: 600,
+      height: 600,
+      type: 'thumb',
+      source: true
+    }}
+    alt=""
+  />
+</HeaderImage>
+
+<CodeBlock>
+  ```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
+
+  <CldImage
+    width="300"
+    height="300"
+    src="<Your Public ID>"
+    sizes="100vw"
+    crop={{
+      width: 600,
+      height: 600,
+      type: 'thumb',
+      source: true
+    }}
+    alt=""
+  />
+  ```
+</CodeBlock>
+
+Which will provide a consistent crop for all rendered sizes.
+
+Learn more about [cropping](/cldimage/configuration#crop) and [responsive images](/guides/responsive-images).
 
 #### Fill Parent
 

--- a/docs/pages/cldogimage/basic-usage.mdx
+++ b/docs/pages/cldogimage/basic-usage.mdx
@@ -1,10 +1,11 @@
 import Head from 'next/head';
 import { Callout } from 'nextra-theme-docs';
 
-import { CldImage } from '../../../next-cloudinary';
-
 import OgImage from '../../components/OgImage';
 import Video from '../../components/Video';
+import HeaderImage from '../../components/HeaderImage';
+import CodeBlock from '../../components/CodeBlock';
+import ExamplesCldOgImage from '../../components/ExamplesCldOgImage';
 
 <Head>
   <title>CldOgImage - Next Cloudinary</title>
@@ -29,13 +30,24 @@ The CldOgImageComponent give you the ability to use the same CldImage API to eas
 
 The basic required prop is `src`:
 
-```jsx copy
-import { CldOgImage } from 'next-cloudinary';
+<HeaderImage>
+  <ExamplesCldOgImage
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
+    alt="Turtle in the ocean"
+  />
+</HeaderImage>
 
-<CldOgImage
-  src="<Public ID>"
-/>
-```
+> CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. The following examples make use of the `<CldImage>` tag to showcase what's possible.
+
+<CodeBlock className="mt-6">
+  ```jsx copy showLineNumbers
+  import { CldOgImage } from 'next-cloudinary';
+
+  <CldOgImage
+    src="<Public ID>"
+  />
+  ```
+</CodeBlock>
 
 Place the CldOgImage component anywhere outside of the Head component.
 
@@ -46,31 +58,15 @@ Place the CldOgImage component anywhere outside of the Head component.
 The resulting HTML will be applied to the Head of the document including all applicable [open graph tags](https://ogp.me/):
 
 ```html copy
-<meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/c_scale,w_1200/f_jpg/q_auto/v1/images/galaxy" />
-<meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/c_scale,w_1200/f_jpg/q_auto/v1/images/galaxy" />
+<meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_1200,h_627,g_center/c_limit,w_1200/f_jpg/q_auto/v1/images/galaxy" />
+<meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_1200,h_627,g_center/c_limit,w_1200/f_jpg/q_auto/v1/images/galaxy" />
 <meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="627" />
+<meta property="og:image:height" content="630" />
 <meta property="twitter:title" content=" " />
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/c_scale,w_1200/f_webp/q_auto/v1/images/galaxy" />
+<meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_1200,h_627,g_center/c_limit,w_1200/f_webp/q_auto/v1/images/galaxy" />
 ```
 
-<div style={{ maxWidth: 500, margin: '0 auto' }}>
-  <p className="nx-mt-6">
-  <CldImage
-    width="1200"
-    height="627"
-    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
-    crop="fill"
-    sizes="100vw"
-    alt="Turtle in the ocean"
-  />
-  </p>
-</div>
-
-<Callout emoji={false}>
-  CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. This example makes use of the `<CldImage>` tag to showcase what's possible.
-</Callout>
 
 ## Transformations
 
@@ -78,34 +74,10 @@ You can further take advantage of Cloudinary features like background removal an
 
 The CldOgImage component uses the same API as [CldImage](/cldimage/configuration), meaning you can use the same transformations and effects.
 
-```jsx copy
-<CldOgImage
-  src="<Public ID>"
-  tint="100:0762a0"
-  removeBackground
-  opacity="40"
-  overlays={[{
-    text: {
-      color: 'white',
-      fontFamily: 'Source Sans Pro',
-      fontSize: 200,
-      fontWeight: 'bold',
-      text: '<Text>'
-    }
-  }]}
-  underlay="<Public ID>"
-  alt="<Description>"
-  twitterTitle="<Title>"
-/>
-```
 
-<div style={{ maxWidth: 500, margin: '0 auto' }}>
-  <p className="nx-mt-6">
-  <CldImage
-    width="1200"
-    height="627"
+<HeaderImage>
+  <ExamplesCldOgImage
     src={`${process.env.IMAGES_DIRECTORY}/turtle`}
-    crop="fill"
     tint="100:0762a0"
     removeBackground
     opacity="40"
@@ -119,15 +91,36 @@ The CldOgImage component uses the same API as [CldImage](/cldimage/configuration
       }
     }]}
     underlay={`${process.env.IMAGES_DIRECTORY}/galaxy`}
-    sizes="100vw"
     alt="Turtle in the ocean"
   />
-  </p>
-</div>
+</HeaderImage>
 
-<Callout emoji={false}>
-  CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. This example makes use of the `<CldImage>` tag to showcase what's possible.
-</Callout>
+> CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. The following examples make use of the `<CldImage>` tag to showcase what's possible.
+
+<CodeBlock className="mt-6">
+  ```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
+
+  <CldOgImage
+    src="<Public ID>"
+    tint="100:0762a0"
+    removeBackground
+    opacity="40"
+    overlays={[{
+      text: {
+        color: 'white',
+        fontFamily: 'Source Sans Pro',
+        fontSize: 80,
+        fontWeight: 'bold',
+        text: '<Text>'
+      }
+    }]}
+    underlay="<Public ID>"
+    alt="<Description>"
+    twitterTitle="<Title>"
+  />
+  ```
+</CodeBlock>
 
 ## Watch & Learn
 

--- a/docs/pages/cldogimage/examples.mdx
+++ b/docs/pages/cldogimage/examples.mdx
@@ -1,11 +1,10 @@
 import Head from 'next/head';
 import { Callout } from 'nextra-theme-docs';
 
-import { CldImage } from '../../../next-cloudinary';
-import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../../next-cloudinary/src/constants/sizes';
-
 import OgImage from '../../components/OgImage';
-import ImageGrid from '../../components/ImageGrid';
+import HeaderImage from '../../components/HeaderImage';
+import CodeBlock from '../../components/CodeBlock';
+import ExamplesCldOgImage from '../../components/ExamplesCldOgImage';
 
 <Head>
   <title>CldOgImage Examples - Next Cloudinary</title>
@@ -20,57 +19,37 @@ import ImageGrid from '../../components/ImageGrid';
 
 # CldOgImage Examples
 
-<Callout emoji={false}>
-  CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. The following examples make use of the `<CldImage>` tag to showcase what's possible.
-</Callout>
+> CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. The following examples make use of the `<CldImage>` tag to showcase what's possible.
 
-## Effects
+## Basic Image
 
-<ImageGrid columns={1}>
-  <li>
-    <CldImage
-      width={OG_IMAGE_WIDTH}
-      height={OG_IMAGE_HEIGHT}
-      crop="fill"
-      gravity="auto"
-      src={`${process.env.IMAGES_DIRECTORY}/white`}
-      sizes="100vw"
-      text="Next Cloudinary"
-      alt="Next Cloudinary"
-    />
+`src`: Specifies a public ID to use as the image
 
-    ### Text over a white background
+<HeaderImage>
+  <ExamplesCldOgImage
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
+  />
+</HeaderImage>
 
-    ```jsx copy
-    text="Next Cloudinary"
-    ```
-  </li>
-  <li>
-    <CldImage
-      width={OG_IMAGE_WIDTH}
-      height={OG_IMAGE_HEIGHT}
-      crop="fill"
-      gravity="auto"
-      src={`${process.env.IMAGES_DIRECTORY}/turtle`}
-      tint="100:0000FF:0p:FF1493:100p"
-      blur="2000"
-      removeBackground
-      overlays={[{
-        text: {
-          color: 'white',
-          fontFamily: 'Source Sans Pro',
-          fontSize: 200,
-          fontWeight: 'bold',
-          text: 'Next Cloudinary'
-        }
-      }]}
-      underlay="images/galaxy"
-      alt="Next Cloudinary on a Galaxy"
-    />
+<CodeBlock className="mt-6">
+  ```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
 
-    ### Background removal with custom background
+  <CldOgImage
+    src="<Public ID>"
+  />
+  ```
+</CodeBlock>
 
-    ```jsx copy
+## Background Removal
+
+#### Image Background
+
+`underlay`: Specifies a public ID to use as an underlaying image.
+
+<HeaderImage>
+  <ExamplesCldOgImage
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
     tint="100:0000FF:0p:FF1493:100p"
     blur="2000"
     removeBackground
@@ -78,16 +57,74 @@ import ImageGrid from '../../components/ImageGrid';
       text: {
         color: 'white',
         fontFamily: 'Source Sans Pro',
-        fontSize: 200,
+        fontSize: 120,
         fontWeight: 'bold',
         text: 'Next Cloudinary'
       }
     }]}
     underlay="images/galaxy"
-    ```
-  </li>
-</ImageGrid>
+  />
+</HeaderImage>
 
+<CodeBlock className="mt-6">
+  ```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
 
+  <CldOgImage
+    src="<Public ID>"
+    tint="100:0000FF:0p:FF1493:100p"
+    blur="2000"
+    removeBackground
+    overlays={[{
+      text: {
+        color: 'white',
+        fontFamily: 'Source Sans Pro',
+        fontSize: 120,
+        fontWeight: 'bold',
+        text: 'Next Cloudinary'
+      }
+    }]}
+    underlay="images/galaxy"
+  />
+  ```
+</CodeBlock>
 
+## Text Overlays
 
+Text overlays allow you to place text on top of an image.
+
+### Adding Custom Text
+
+`overlays`: Uses overlay objects to add text on top of an image.
+
+<HeaderImage>
+  <ExamplesCldOgImage
+    src={`${process.env.IMAGES_DIRECTORY}/white`}
+    overlays={[{
+      text: {
+        fontFamily: 'Source Sans Pro',
+        fontSize: 120,
+        fontWeight: 'bold',
+        text: 'Next Cloudinary'
+      }
+    }]}
+  />
+</HeaderImage>
+
+<CodeBlock className="mt-6">
+  ```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
+
+  <CldOgImage
+    src="<Public ID>"
+    overlays={[{
+      text: {
+        fontFamily: 'Source Sans Pro',
+        fontSize: 120,
+        fontWeight: 'bold',
+        text: 'Next Cloudinary'
+      }
+    }]}
+  />
+  ```
+</CodeBlock>

--- a/docs/pages/getcldimageurl/basic-usage.mdx
+++ b/docs/pages/getcldimageurl/basic-usage.mdx
@@ -78,7 +78,7 @@ const url = getCldImageUrl({
       crop: {
         width: 600,
         height: 600,
-        crop: 'thumb',
+        type: 'thumb',
         source: true
       },
       tint: '50:blue:green:red',

--- a/docs/pages/getcldimageurl/basic-usage.mdx
+++ b/docs/pages/getcldimageurl/basic-usage.mdx
@@ -75,7 +75,12 @@ const url = getCldImageUrl({
       src: `${process.env.IMAGES_DIRECTORY}/galaxy`,
       width: 600,
       height: 600,
-      crop: 'thumb',
+      crop: {
+        width: 600,
+        height: 600,
+        crop: 'thumb',
+        source: true
+      },
       tint: '50:blue:green:red',
       blur: 1000,
     })}

--- a/docs/pages/getcldimageurl/configuration.mdx
+++ b/docs/pages/getcldimageurl/configuration.mdx
@@ -1,6 +1,8 @@
 import Head from 'next/head';
+import { Callout } from 'nextra-theme-docs';
 
 import OgImage from '../../components/OgImage';
+import Table from '../../components/Table';
 
 <Head>
   <title>getCldImageUrl Configuration - Next Cloudinary</title>
@@ -19,138 +21,1870 @@ Configuration for getCldImageUrl is the same as [CldImage](/cldimage/configurati
 
 The function takes two main arguments: options and config.
 
-| Option Name        | Type               | Default    | Example                      |
-|--------------------|--------------------|------------|------------------------------|
-| options            | object             | -          | `{ src: 'myimage', ... }`      |
-| config             | object             | -          | `{ cloud: { cloudName: 'name' } }` |
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    },
+  ]}
+  data={[
+    {
+      name: 'options',
+      type: 'object',
+      example: () => (<code>{`{ src: 'myimage', ... }`}</code>),
+    },
+    {
+      name: 'config',
+      type: 'object',
+      example: () => (<code>{`{ cloud: { cloudName: 'name' } }`}</code>),
+      more: () => (<a href="https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters">More Info</a>)
+    },
+  ]}
+/>
 
 The function also accepts a third argument of `analytics` that's intended to be used configure analytics properties for usage statistics.
 
-## General Options
+## Basic Options
 
-| Option Name        | Type               | Default    | Example                      |
-|--------------------|--------------------|------------|------------------------------|
-| crop               | string             | `"limit"`  | `"thumb"`                    |
-| deliveryType       | string             | `"upload"` | `"fetch"`                    |
-| dpr                | number/string      | -          | `"2.0"`                      |
-| effects            | array              | -          | `[{ background: 'blue' }]`   |
-| format             | string             | `"auto"`   | `"webp"`                     |
-| fillBackground (Beta) | bool/object     | -          | `{{ gravity: 'east' }}`      |
-| gravity            | string             | `"auto"`   | `"faces"`                    |
-| height             | number/string      | -          | `600`                        |
-| overlays           | array              | -          | See Below                    |
-| preserveTransformations | string        | `false`    | `true`                       |
-| quality            | string             | `"auto"`   | `"90"`                       |
-| rawTransformations | array              | -          | `['e_blur:2000']`            |
-| removeBackground   | bool/string        | `false`    | `true`                       |
-| sanitize           | bool               | `true` if svg | `true` (Applies only to SVG) |
-| seoSuffix          | string             | -          | `my-image-content`           |
-| src                | string             | -          | `"my-public-id"`             |
-| text               | string             | -          | `"Next Cloudinary"`          |
-| transformations    | string/array       | -          | `['my-named-transformation']`|
-| underlay           | string             | -          | `"my-public-id"`             |
-| underlays          | array              | -          | See Below                    |
-| version            | number             | -          | `1234`                       |
-| width              | number/string      | -          | `600`                        |
-| zoom               | string             | -          | `0.5`                        |
-| zoompan            | bool/string/object | -          | See Below                    |
+The basic options available to use with getCldImageUrl include:
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'required',
+      title: 'Required'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    },
+  ]}
+  data={[
+    {
+      name: 'height',
+      type: 'number/string',
+      required: () => (<span>Yes, unless using Next Image <code><a href="https://nextjs.org/docs/pages/api-reference/components/image#fill">fill</a></code></span>),
+      example: () => (<code>600</code>),
+      more: () => (<a href="https://nextjs.org/docs/pages/api-reference/components/image#height">More Info</a>)
+    },
+    {
+      name: 'src',
+      type: 'string',
+      required: 'Yes',
+      example: () => (<code>my-public-id</code>)
+    },
+    {
+      name: 'width',
+      type: 'number/string',
+      required: () => (<span>Yes, unless using Next Image <code><a href="https://nextjs.org/docs/pages/api-reference/components/image#fill">fill</a></code></span>),
+      example: () => (<code>600</code>),
+      more: () => (<a href="https://nextjs.org/docs/pages/api-reference/components/image#width">More Info</a>)
+    },
+  ]}
+/>
+
+## Basic Transformations
+
+The getCldImageUrl helper exposes many of Cloudinary's transformations in an easy-to-use way
+right inside of Next.js.
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'default',
+      title: 'Default'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    }
+  ]}
+  data={[
+    {
+      name: 'background',
+      type: 'string',
+      default: '-',
+      example: () => (<span><code>blue</code>, <code>rgb:0000ff</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#b_background">More Info</a>)
+    },
+
+    {
+      name: 'crop',
+      type: 'string | object',
+      default: () => (<code>limit</code>),
+      example: () => (<code>fill</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#c_crop_resize">More Info</a>)
+    },
+    {
+      name: 'fillBackground (Beta)',
+      type: 'boolean | object',
+      default: '-',
+      example: () => (<code>{`{{ gravity: 'east' }}`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#b_gen_fill">More Info</a>)
+    },
+    {
+      name: 'gravity',
+      type: 'string',
+      default: () => (<code>auto</code>),
+      example: () => (<code>faces</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#g_gravity">More Info</a>)
+    },
+    {
+      name: 'recolor',
+      type: 'array | object',
+      default: '-',
+      example: () => (<code>{`['duck', 'blue']`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_gen_recolor">More Info</a>)
+    },
+    {
+      name: 'remove',
+      type: 'string | array | object',
+      default: '-',
+      example: () => (<code>{`apple`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_gen_remove">More Info</a>)
+    },
+    {
+      name: 'removeBackground',
+      type: 'boolean | string',
+      default: () => (<code>false</code>),
+      example: () => (<code>true</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_background_removal">More Info</a>)
+    },
+    {
+      name: 'replace',
+      type: 'array | object',
+      default: '-',
+      example: () => (<code>{`['apple', 'banana']`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_gen_replace">More Info</a>)
+    },
+    {
+      name: 'restore',
+      type: 'boolean',
+      default: '-',
+      example: () => (<code>{`true`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_gen_restore">More Info</a>)
+    },
+    {
+      name: 'zoom',
+      type: 'string',
+      default: '-',
+      example: () => (<code>0.5</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#z_zoom">More Info</a>)
+    },
+    {
+      name: 'zoompan',
+      type: 'boolean | string | object',
+      default: '-',
+      example: () => (<code>true</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_zoompan">More Info</a>)
+    },
+  ]}
+/>
+
+### `background`
+
+Applies a background to empty or transparent areas.
+
+**Examples**
+
+```jsx copy
+background: 'blue'
+```
+
+[Learn more about the background transformation](https://cloudinary.com/documentation/transformation_reference#b_background) on the Cloudinary docs.
+
+### `crop`
+
+Changes the size of the delivered asset according to the requested width & height dimensions.
+
+The `crop` prop can either be a string, which can accept any [valid Cloudinary crop mode](https://cloudinary.com/documentation/transformation_reference#c_crop_resize),
+or it can accept an object or an array of objects which can take the following options:
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    }
+  ]}
+  data={[
+    {
+      name: 'aspectRatio',
+      type: 'string',
+      example: () => (<code>16:9</code>),
+    },
+    {
+      name: 'gravity',
+      type: 'string',
+      example: () => (<a href="#gravity">See Gravity</a>),
+    },
+    {
+      name: 'height',
+      type: 'string',
+      example: () => (<a href="#required-props">See Height</a>),
+    },
+    {
+      name: 'source',
+      type: 'boolean',
+      example: () => (<code>true</code>),
+    },
+    {
+      name: 'type (crop mode)',
+      type: 'string',
+      example: () => (<code>fill</code>),
+    },
+    {
+      name: 'width',
+      type: 'string',
+      example: () => (<a href="#required-props">See Width</a>),
+    },
+    {
+      name: 'zoom',
+      type: 'string',
+      example: () => (<a href="#zoom">See Zoom</a>),
+    },
+  ]}
+/>
+
+**Dynamic Crop Modes**
+
+When using a dynamic crop mode, such as `thumb`, the resulting image may
+be visually different based on the given dimensions. For instance, an
+image cropped using the `thumb` crop mode with dimensions 600x600 will
+give different results than 1200x1200 (assuming a gravity of auto or similar,
+which is the default for getCldImageUrl).
+
+This is especially important in the context of [Responsive Images](/guides/responsive-images)
+where due to the resize mechanism, different device sizes may result
+in different looking images, which doesn't provide a great experience.
+
+To resolve this, when using dynamic crop modes you may want to opt into
+a two-stage crop, first cropping the original source image, then allowing
+the the resize mechanism to handle resizing that to the appropriate device
+size. See examples below.
+
+<Callout emoji={false}>
+  Versions 5 and below of Next Cloudinary automatically opted getCldImageUrl in
+  to a two-stage cropping to help improve the experience, but it came with
+  drawbacks including prematurely limiting the potential resulting size
+  of an image. [Learn more](https://github.com/cloudinary-community/next-cloudinary/discussions/432).
+</Callout>
+
+**Examples**
+
+Cropping an image and filling the containing space:
+
+```jsx copy
+crop: 'fill'
+```
+
+Using a crop of `thumb` on the original source image:
+
+```jsx copy
+crop: {
+  width: 1200,
+  height: 1200,
+  type: 'thumb',
+  source: true
+}
+```
+
+[Learn more about the crop transformation](https://cloudinary.com/documentation/transformation_reference#c_crop_resize) on the Cloudinary docs.
+
+### `fillBackground`
+
+<Callout emoji={false} type="info">
+  Generative Fill is currently in beta.
+</Callout>
+
+Automatically fills the padded area using generative AI to extend the image seamlessly.
+
+The `fillBackground` prop can either be a boolean, which will use a set of safe defaults to produce
+a background, or an object, which can take the following options:
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    }
+  ]}
+  data={[
+    {
+      name: 'crop',
+      type: 'string',
+      example: () => (<code>clpad</code>),
+    },
+    {
+      name: 'gravity',
+      type: 'string',
+      example: () => (<code>south</code>),
+    },
+    {
+      name: 'prompt',
+      type: 'string',
+      example: () => (<code>cupcakes</code>),
+    },
+  ]}
+/>
+
+**Examples**
+
+Applying Generative Fill with defaults:
+
+```jsx copy
+fillBackground: true
+```
+
+Customizing options:
+
+```jsx copy
+fillBackground: {
+  crop: 'clpad',
+  gravity: 'south',
+  prompt: 'cupcakes'
+}
+```
+
+[Learn more about the Generative Fill transformation](https://cloudinary.com/documentation/transformation_reference#b_gen_fill) on the Cloudinary docs.
+
+### `gravity`
+
+Determines which part of an asset to focus on, and thus which part of the asset to keep, when any part of the asset is cropped
+
+**Examples**
+
+```jsx copy
+gravity: 'face'
+```
+
+[Learn more about gravity](https://cloudinary.com/documentation/transformation_reference#g_gravity) on the Cloudinary docs.
+
+### `recolor`
+
+<Callout emoji={false} type="info">
+  Generative Recolor is currently in beta.
+</Callout>
+
+Uses generative AI to recolor parts of your image, maintaining the relative shading.
+
+The `recolor` prop can either be an array with the objects to be replaced or an object
+with the following options:
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    }
+  ]}
+  data={[
+    {
+      name: 'multiple',
+      type: 'boolean',
+      example: () => (<code>true</code>),
+    },
+    {
+      name: 'prompt',
+      type: 'string | array',
+      example: () => (<span><code>duck</code> or <code>['duck', 'horse']</code></span>),
+    },
+    {
+      name: 'to',
+      type: 'string',
+      example: () => (<code>blue</code>),
+    },
+  ]}
+/>
+
+**Examples**
+
+Recoloring an object with an array:
+
+```jsx copy
+recolor: ['duck', 'blue']
+```
+
+Or using the object format:
+
+```jsx copy
+recolor: {
+  prompt: 'duck',
+  to: 'blue',
+  multiple; true
+}
+```
+
+[Learn more about the Generative Recolor transformation](https://cloudinary.com/documentation/transformation_reference#e_gen_recolor) on the Cloudinary docs.
+
+### `remove`
+
+<Callout emoji={false} type="info">
+  Generative Remove is currently in beta.
+</Callout>
+
+Uses generative AI to remove unwanted parts of your image, replacing the area with realistic pixels.
+
+The `remove` prop can either be a string, an array, or an object with the following options:
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    }
+  ]}
+  data={[
+    {
+      name: 'multiple',
+      type: 'boolean',
+      example: () => (<code>true</code>),
+    },
+    {
+      name: 'prompt',
+      type: 'string | array',
+      example: () => (<span><code>duck</code> or <code>['duck', 'horse']</code></span>),
+    },
+    {
+      name: 'removeShadow',
+      type: 'boolean',
+      example: () => (<code>true</code>),
+    },
+    {
+      name: 'region',
+      type: 'array',
+      example: () => (<code>[300, 200, 1900, 3500]</code>),
+    },
+  ]}
+/>
+
+**Examples**
+
+Removing an object by string:
+
+```jsx copy
+remove: 'apple'
+```
+
+Removing multiple objects by array:
+
+```jsx copy
+remove: ['apple', 'banana', 'orange']
+```
+
+Removing multiple instances of an object and their shadow with object configuration:
+
+```jsx copy
+remove: {
+  prompt: 'apple',
+  multiple: true,
+  removeShadow: true
+}
+```
+
+Removing a region:
+
+```jsx copy
+remove: {
+  region: [300, 200, 1900, 3500]
+}
+```
+
+Removing multiple regions:
+
+```jsx copy
+remove: {
+  region: [
+    [300, 200, 1900, 3500],
+    [123, 321, 750, 500]
+  ]
+}
+```
+
+[Learn more about the Generative Remove transformation](https://cloudinary.com/documentation/transformation_reference#e_gen_remove) on the Cloudinary docs.
+
+### `removeBackground`
+
+Uses the [Cloudinary AI Background Removal add-on](https://cloudinary.com/documentation/cloudinary_ai_background_removal_addon) to make the background of an image transparent.
+
+<Callout emoji={false} type="info">
+  The Cloudinary AI Background Removal add-on is required to use this feature.
+</Callout>
 
 
-## Effect Options
+**Examples**
 
-| Option Name        | Type        | Default | Example                                              |
-| ------------------ | ----------- | ------- | ---------------------------------------------------- |
-| art                | string      | -       |`"al_dente"`                                         |
-| autoBrightness     | bool/string | -       |`true`, `"80"`                                       |
-| autoColor          | bool/string | -       |`true`, `"80"`                                       |
-| autoContrast       | bool/string | -       |`true`, `"80"`                                       |
-| assistColorblind   | bool/string | -       |`true`, `"20"`, `"xray"`                             |
-| background         | string      | -       |`"blue"`                                             |
-| blackwhite         | bool/string | -       |`true`, `"40"`                                       |
-| blur               | bool/string | -       |`true`, `"800"`                                      |
-| blurFaces          | bool/string | -       |`true`, `"800"`                                      |
-| blurRegion         | bool/string | -       |`true`, `"1000,h_425,w_550,x_600,y_400"`             |
-| border             | string      | -       |`"5px_solid_purple"`                                 |
-| brightness         | bool/string | -       |`true`, `"100"`                                      |
-| brightnessHSB      | bool/string | -       |`true`, `"100"`                                      |
-| cartoonify         | bool/string | -       |`true`, `"70:80"`                                    |
-| color              | string      | -       |`"blue"`                                             |
-| colorize           | string      | -       |`"35,co_darkviolet"`                                 |
-| contrast           | bool/string | -       |`true`, `"100"`, `"level_-70"`                       |
-| distort            | string      | -       |`"150:340:1500:10:1500:1550:50:1000"`, `"arc:180.0"` |
-| fillLight          | bool/string | -       |`true`, `"70:20"`                                    |
-| gamma              | bool/string | -       |`true`, `"100"`                                      |
-| gradientFade       | bool/string | -       |`true`, `"symmetric:10,x_0.2,y_0.4"`                 |
-| grayscale          | bool        | -       |`true`                                               |
-| improve            | bool/string | -       |`true`, `"50"`, `"indoor"`                           |
-| multiply           | bool        | -       |`true`                                               |
-| negate             | bool        | -       |`true`                                               |
-| oilPaint           | bool/string | -       |`true`, `"40"`                                       |
-| opacity            | number/string | -     |`40`, `"40"`                                       |
-| outline            | bool/string | -       |`true`, `"40"`, `"outer:15:200"`                     |
-| overlay            | bool        | -       |`true`                                               |
-| pixelate           | bool/string | -       |`true`, `"20"`                                       |
-| pixelateFaces      | bool/string | -       |`true`, `"20"`                                       |
-| pixelateRegion     | bool/string | -       |`true`, `"35,h_425,w_550,x_600,y_400"`               |
-| redeye             | bool/string | -       |`true`                                               |
-| replaceColor       | string      | -       |`"saddlebrown"`, `"2F4F4F:20"`, `"silver:55:89b8ed"` |
-| saturation         | bool/string | -       |`true`, `"70"`                                       |
-| screen             | bool        | -       |`true`                                               |
-| sepia              | bool/string | -       |`true`, `"50"`                                       |
-| shadow             | bool/string | -       |`true`, `"50,x_-15,y_15"`                            |
-| sharpen            | bool/string | -       |`true`, `"100"`                                      |
-| shear              | string      | -       |`"20.0:0.0"`                                         |
-| simulateColorblind | bool/string | -       |`"deuteranopia"`                                     |
-| tint               | bool/string | -       |`true`, `"100:red:blue:yellow"`                      |
-| unsharpMask        | bool/string | -       |`true`, `"500"`                                      |
-| vectorize          | bool/string | -       |`true`, `"3:0.5"`                                    |
-| vibrance           | bool/string | -       |`true`, `"70"`                                       |
-| vignette           | bool/string | -       |`true`, `"30"`                                       |
+```jsx copy
+removeBackground: true
+```
+
+[Learn more about background removal transformation](https://cloudinary.com/documentation/transformation_reference#e_background_removal) on the Cloudinary docs.
+
+
+### `replace`
+
+<Callout emoji={false} type="info">
+  Generative Replace is currently in beta.
+</Callout>
+
+Uses generative AI to replace parts of your image with something else. 
+
+The `replace` prop can either be an array with the objects to be replaced or an object
+with the following options:
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    }
+  ]}
+  data={[
+    {
+      name: 'from',
+      type: 'string',
+      example: () => (<code>apple</code>),
+    },
+    {
+      name: 'to',
+      type: 'string',
+      example: () => (<code>banana</code>),
+    },
+    {
+      name: 'preserveGeometry',
+      type: 'boolean',
+      example: () => (<code>true</code>),
+    },
+  ]}
+/>
+
+**Examples**
+
+Replacing an object with an array:
+
+```jsx copy
+replace: ['apple', 'banana']
+```
+
+Or using the object format:
+
+```jsx copy
+replace: {
+  from: 'apple',
+  to: 'banana',
+  preserveGeometry; true
+}
+```
+
+[Learn more about the Generative Replace transformation](https://cloudinary.com/documentation/transformation_reference#e_gen_replace) on the Cloudinary docs.
+
+### `restore`
+
+<Callout emoji={false} type="info">
+  Generative Restore is currently in beta.
+</Callout>
+
+Uses generative AI to restore details in poor quality images or images that may have become degraded through repeated processing and compression.
+
+The `restore` prop can be used as a boolean.
+
+**Examples**
+
+```jsx copy
+restore: true
+```
+
+[Learn more about the Generative Restore transformation](https://cloudinary.com/documentation/transformation_reference#e_gen_restore) on the Cloudinary docs.
+
+
+### `zoom`
+
+Controls how close to crop to the detected coordinates when using face-detection, custom-coordinate, or object-specific gravity.
+
+**Examples**
+
+```jsx copy
+zoom: '0.75'
+```
+
+[Learn more about the zoom transformation](https://cloudinary.com/documentation/transformation_reference#z_zoom) on the Cloudinary docs.
+
+### `zoompan`
+
+Also known as the Ken Burns effect, this transformation applies zooming and/or panning to an image, resulting in a video or animated GIF.
+
+`zoompan` can be applied with safe defaults as a boolean, a string, or an object for
+advanced customization.
+
+As a string, you can pass in "loop" to automatically loop, or you can pass in raw configuration using the Cloudinary
+Transformation syntax.
+
+As an object, you can use advanced configuration with the following options:
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    }
+  ]}
+  data={[
+    {
+      name: 'loop',
+      type: 'boolean | string',
+      example: () => (<code>true</code>),
+    },
+    {
+      name: 'options',
+      type: 'boolean | string',
+      example: () => (<code>mode_ztr;maxzoom_6.5;du_10</code>),
+    },
+  ]}
+/>
+
+**Examples**
+
+With defaults:
+
+```jsx copy
+zoompan: true
+```
+
+Add looping:
+
+```jsx copy
+zoompan: 'loop'
+```
+
+Customize options:
+
+```jsx copy
+zoompan: {
+  loop: 'loop:2', // Will loop twice
+  options: 'mode_ztr;maxzoom_6.5;du_10'
+}
+```
+
+[Learn more about the zoompan transformation](https://cloudinary.com/documentation/transformation_reference#e_zoompan) on the Cloudinary docs.
+
+
+## Filters & Effects
+
+Cloudinary supports a wide variety of effects and artistic filters that help
+to easily change the appearance of an image.
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'default',
+      title: 'Default'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    }
+  ]}
+  data={[
+    {
+      name: 'art',
+      type: 'string',
+      default: '-',
+      example: () => (<code>al_dente</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_art">More Info</a>)
+    },
+    {
+      name: 'autoBrightness',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>80</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_auto_brightness">More Info</a>)
+    },
+    {
+      name: 'autoColor',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>80</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_auto_color">More Info</a>)
+    },
+    {
+      name: 'autoContrast',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>80</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_auto_contrast">More Info</a>)
+    },
+    {
+      name: 'assistColorblind',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>20</code>, <code>xray</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_assist_colorblind">More Info</a>)
+    },
+    {
+      name: 'blackwhite',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>40</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_blackwhite">More Info</a>)
+    },
+    {
+      name: 'blur',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>800</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_blur">More Info</a>)
+    },
+    {
+      name: 'blurFaces',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>800</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_blur_faces">More Info</a>)
+    },
+    {
+      name: 'blurRegion',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>1000,h_425,w_550,x_600,y_400</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_blur_region">More Info</a>)
+    },
+    {
+      name: 'border',
+      type: 'string',
+      default: '-',
+      example: () => (<code>5px_solid_purple</code>)
+    },
+    {
+      name: 'brightness',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>100</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_brightness">More Info</a>)
+    },
+    {
+      name: 'brightnessHSB',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>100</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_brightness_hsb">More Info</a>)
+    },
+    {
+      name: 'cartoonify',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>70:80</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_cartoonify">More Info</a>)
+    },
+    {
+      name: 'color',
+      type: 'string',
+      default: '-',
+      example: () => (<code>blue</code>),
+    },
+    {
+      name: 'colorize',
+      type: 'string',
+      default: '-',
+      example: () => (<code>35,co_darkviolet</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_colorize">More Info</a>)
+    },
+    {
+      name: 'contrast',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>100</code>, <code>level_-70</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_contrast">More Info</a>)
+    },
+    {
+      name: 'distort',
+      type: 'string',
+      default: '-',
+      example: () => (<span><code>150:340:1500:10:1500:1550:50:1000</code>, <code>arc:180.0</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_distort">More Info</a>)
+    },
+    {
+      name: 'fillLight',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>70:20</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_fill_light">More Info</a>)
+    },
+    {
+      name: 'gamma',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>100</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_gamma">More Info</a>)
+    },
+    {
+      name: 'gradientFade',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>symmetric:10,x_0.2,y_0.4</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_gradient_fade">More Info</a>)
+    },
+    {
+      name: 'grayscale',
+      type: 'bool',
+      default: '-',
+      example: () => (<code>true</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_grayscale">More Info</a>)
+    },
+    {
+      name: 'improve',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>50</code>, <code>indoor</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_improve">More Info</a>)
+    },
+    {
+      name: 'multiply',
+      type: 'bool',
+      default: '-',
+      example: () => (<code>true</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_multiply">More Info</a>)
+    },
+    {
+      name: 'negate',
+      type: 'bool',
+      default: '-',
+      example: () => (<code>true</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_negate">More Info</a>)
+    },
+    {
+      name: 'oilPaint',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>40</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_oil_paint">More Info</a>)
+    },
+    {
+      name: 'opacity',
+      type: 'number/string',
+      default: '-',
+      example: () => (<code>40</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#o_opacity">More Info</a>)
+    },
+    {
+      name: 'outline',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>40</code>, <code>outer:15:200</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_outline">More Info</a>)
+    },
+    {
+      name: 'overlay',
+      type: 'bool',
+      default: '-',
+      example: () => (<code>true</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_overlay">More Info</a>)
+    },
+    {
+      name: 'pixelate',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>20</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_pixelate">More Info</a>)
+    },
+    {
+      name: 'pixelateFaces',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>20</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_pixelate_faces">More Info</a>)
+    },
+    {
+      name: 'pixelateRegion',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>35,h_425,w_550,x_600,y_400</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_pixelate_region">More Info</a>)
+    },
+    {
+      name: 'redeye',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<code>true</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_redeye">More Info</a>)
+    },
+    {
+      name: 'replaceColor',
+      type: 'string',
+      default: '-',
+      example: () => (<span><code>saddlebrown</code>, <code>2F4F4F:20</code>, <code>silver:55:89b8ed</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_replace_color">More Info</a>)
+    },
+    {
+      name: 'sanitize',
+      type: 'bool',
+      default: () => (<span><code>true</code> if .svg</span>),
+      example: () => (<span><code>true</code> - Only applies to .svg</span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#fl_sanitize">More Info</a>)
+    },
+    {
+      name: 'saturation',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>70</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_saturation">More Info</a>)
+    },
+    {
+      name: 'screen',
+      type: 'bool',
+      default: '-',
+      example: () => (<code>true</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_screen">More Info</a>)
+    },
+    {
+      name: 'sepia',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>50</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_sepia">More Info</a>)
+    },
+    {
+      name: 'shadow',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>50,x_-15,y_15</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_shadow">More Info</a>)
+    },
+    {
+      name: 'sharpen',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>100</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_sharpen">More Info</a>)
+    },
+    {
+      name: 'shear',
+      type: 'string',
+      default: '-',
+      example: () => (<code>20.0:0.0</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_shear">More Info</a>)
+    },
+    {
+      name: 'simulateColorblind',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<code>deuteranopia</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_simulate_colorblind">More Info</a>)
+    },
+    {
+      name: 'tint',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>100:red:blue:yellow</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_tint">More Info</a>)
+    },
+    {
+      name: 'trim',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>50:yellow</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_trim">More Info</a>)
+    },
+    {
+      name: 'unsharpMask',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>500</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_unsharp_mask">More Info</a>)
+    },
+    {
+      name: 'vectorize',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>3:0.5</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_vectorize">More Info</a>)
+    },
+    {
+      name: 'vibrance',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>70</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_vibrance">More Info</a>)
+    },
+    {
+      name: 'vignette',
+      type: 'boolean | string',
+      default: '-',
+      example: () => (<span><code>true</code>, <code>30</code></span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_vignette">More Info</a>)
+    }
+  ]}
+/>
+
+**Examples**
+
+Make an image black and white:
+
+```jsx copy
+blackwhite: true
+```
+
+Pixelate an image:
+
+```jsx copy
+pixelate: true
+```
+
+Sharpen an image:
+
+```jsx copy
+sharpen: 50
+```
 
 [View the Cloudinary docs](https://cloudinary.com/documentation/transformation_reference#e_effect) to see learn more about using effects.
 
-### Overlay Options
+## Overlays & Underlays
 
-The `overlays` prop is an array of objects with the following configuration options:
+Cloudinary gives you the ability to add layers above or below your primary asset using Overlays and Underlays.
 
-| Property Name    | Type          | Example                              |
-|------------------|---------------|--------------------------------------|
-| appliedEffects   | array         | Same as effects, added as applied transformation |
-| effects          | array         | See Below                            |
-| position         | object        | See Below                            |
-| publicId         | string        | `"thumb"`                            |
-| text             | object|string | `"Next Cloudinary"` or See Below     |
-| url              | string        | `"https://.../image.jpg"`            |
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+  ]}
+  data={[
+    {
+      name: 'overlays',
+      type: 'array',
+      default: '-',
+      example: () => (<a href="#customizing-overlays--underlays">Customizing Overlays & Underlays</a>),
+    },
+    {
+      name: 'text',
+      type: 'string',
+      default: '-',
+      example: () => (<code>Next Cloudinary</code>),
+    },
+    {
+      name: 'underlay',
+      type: 'string',
+      default: '-',
+      example: () => (<code>my-public-id</code>),
+    },
+    {
+      name: 'underlays',
+      type: 'array',
+      default: '-',
+      example: () => (<a href="#customizing-overlays--underlays">Customizing Overlays & Underlays</a>),
+    },
+  ]}
+/>
 
-The position property can include:
+### Customizing Overlays & Underlays
 
-| Property Name | Type   | Example        |
-| ------------- | ------ | -------------- |
-| angle         | number | `45`           |
-| gravity       | string | '"north_west"' |
-| x             | number | `10`           |
-| y             | number | `10`           |
+> Note: The API for Underlays is similar to Overlays except they do not support text.
 
-Objects in the effects array can include everything in the effects options above as well as:
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+  ]}
+  data={[
+    {
+      name: 'appliedEffects',
+      type: 'array',
+      example: () => (<span><a href="#layer-effect-props">effects</a>, added as applied transformation</span>),
+    },
+    {
+      name: 'effects',
+      type: 'array',
+      example: () => (<a href="#layer-effect-props">effects</a>),
+    },
+    {
+      name: 'position',
+      type: 'object',
+      example: () => (<a href="#layer-position-props">position</a>),
+    },
+    {
+      name: 'publicId',
+      type: 'string',
+      example: () => (<code>mypublicid</code>),
+    },
+    {
+      name: 'text',
+      type: 'object|string',
+      example: () => (<span><code>Next Cloudinary</code> or See <a href="#layer-text-props">text</a> Below</span>),
+    },
+    {
+      name: 'url',
+      type: 'string',
+      example: () => (<code>https://.../image.jpg</code>),
+    },
+  ]}
+/>
 
-| Property Name | Type   | Example        |
-| ------------- | ------ | -------------- |
-| aspectRatio   | string | `"3.0"`        |
-| crop          | string | `10`           |
-| gravity       | string | '"north_west"' |
-| height        | number | '600'          |
-| width         | number | '600'          |
+**Examples**
 
-The text property can include:
+Adding an overlay:
 
-| Property Name  | Type   | Example                                    |
-| -------------- | ------ | ------------------------------------------ |
-| border         | string | `"20px_solid_blue"`                        |
-| color          | string | `"blueviolet"`                             |
-| fontFamily     | string | `"Open Sans"`                              |
-| fontSize       | number | `48`                                       |
-| fontWeight     | string | `"bold"`                                   |
-| letterSpacing  | number | `"14"`                                     |
-| lineSpacing    | number | `"14"`                                     |
-| stroke         | bool   | `true` in coordination with Border         |
-| textDecoration | string | `"underline"`                              |
+```jsx copy
+overlays: [{
+  publicId: 'images/earth',
+  position: {
+    x: 50,
+    y: 50,
+    gravity: 'north_west',
+  },
+  appliedEffects: [
+    {
+      multiply: true
+    }
+  ]
+}]
+```
+
+Adding an underlay:
+
+```jsx copy
+underlays: [{
+  publicId: 'images/earth',
+}]
+```
+
+<div className="-mb-4">
+  <strong id="layer-effect-props" className="block text-slate-500 text-lg mt-8 -mb-4">
+    <code>effects</code>
+  </strong>
+  
+  Objects in the `effects` array can include everything in [Basic Transformations](##basic-transformations) and [Filters & Effects](#filters--effects) above as well as:
+</div>
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more',
+    },
+  ]}
+  data={[
+    {
+      name: 'aspectRatio',
+      type: 'string',
+      example: () => (<code>3.0</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#ar_aspect_ratio">More Info</a>)
+    },
+
+    {
+      name: 'crop',
+      type: 'string',
+      example: () => (<code>10</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#c_crop_resize">More Info</a>)
+    },
+
+    {
+      name: 'gravity',
+      type: 'string',
+      example: () => (<code>north_west</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#g_gravity">More Info</a>)
+    },
+
+    {
+      name: 'height',
+      type: 'number',
+      example: () => (<code>600</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#h_height">More Info</a>)
+    },
+
+    {
+      name: 'width',
+      type: 'number',
+      example: () => (<code>600</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#w_width">More Info</a>)
+    },
+  ]}
+/>
+
+<div className="-mb-4">
+  <strong id="layer-position-props" className="block text-slate-500 text-lg mt-8 -mb-4">
+    <code>position</code>
+  </strong>
+
+  The `position` property can include:
+</div>
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    },
+  ]}
+  data={[
+    {
+      name: 'angle',
+      type: 'number',
+      example: () => (<code>45</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#a_angle">More Info</a>)
+    },
+    {
+      name: 'gravity',
+      type: 'string',
+      example: () => (<code>north_west</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#g_gravity">More Info</a>)
+    },
+    {
+      name: 'x',
+      type: 'number',
+      example: () => (<code>10</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#x_y_coordinates">More Info</a>)
+    },
+    {
+      name: 'y',
+      type: 'number',
+      example: () => (<code>10</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#x_y_coordinates">More Info</a>)
+    },
+  ]}
+/>
+
+<div className="-mb-4">
+  <strong id="layer-text-props" className="block text-slate-500 text-lg mt-8 -mb-4">text</strong>
+
+  The `text` property can include:
+</div>
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more',
+    },
+  ]}
+  data={[
+    {
+      name: 'border',
+      type: 'string',
+      example: () => (<code>20px_solid_blue</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#bo_border">More Info</a>)
+    },
+    {
+      name: 'color',
+      type: 'string',
+      example: () => (<code>blueviolet</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#co_color">More Info</a>)
+    },
+    {
+      name: 'fontFamily',
+      type: 'string',
+      example: () => (<code>Open Sans</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#styling_parameters">More Info</a>)
+    },
+    {
+      name: 'fontSize',
+      type: 'number',
+      example: () => (<code>48</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#styling_parameters">More Info</a>)
+    },
+    {
+      name: 'fontWeight',
+      type: 'string',
+      example: () => (<code>bold</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#styling_parameters">More Info</a>)
+    },
+    {
+      name: 'letterSpacing',
+      type: 'number',
+      example: () => (<code>14</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#styling_parameters">More Info</a>)
+    },
+    {
+      name: 'lineSpacing',
+      type: 'number',
+      example: () => (<code>14</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#styling_parameters">More Info</a>)
+    },
+    {
+      name: 'stroke',
+      type: 'bool',
+      example: () => (<span><code>true</code> in coordination with Border</span>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#styling_parameters">More Info</a>)
+    },
+    {
+      name: 'textDecoration',
+      type: 'string',
+      example: () => (<code>underline</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#styling_parameters">More Info</a>)
+    },
+  ]}
+/>
+
+## Advanced
+
+### Configuration & Delivery
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'default',
+      title: 'Default'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    }
+  ]}
+  data={[
+    {
+      name: 'assetType',
+      type: 'string',
+      default: () => (<code>image</code>),
+      example: () => (<code>video</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/image_transformations#transformation_url_structure">More Info</a>)
+    },
+    {
+      name: 'config',
+      type: 'object',
+      default: '-',
+      example: () => (<code>{`{ url: { secureDistribution: 'spacejelly.dev' } }`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters">More Info</a>)
+    },
+    {
+      name: 'deliveryType',
+      type: 'string',
+      default: () => (<code>upload</code>),
+      example: () => (<code>fetch</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/image_transformations#delivery_types">More Info</a>)
+    },
+    {
+      name: 'defaultImage',
+      type: 'string',
+      default: '-',
+      example: () => (<code>myimage.jpg</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#d_default_image">More Info</a>)
+    },
+    {
+      name: 'flags',
+      type: 'array',
+      default: '-',
+      example: () => (<code>{`['keep_iptc']`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#fl_flag">More Info</a>)
+    },
+    {
+      name: 'seoSuffix',
+      type: 'string',
+      default: '-',
+      example: () => (<code>my-image-content</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/advanced_url_delivery_options#dynamic_seo_suffixes">More Info</a>)
+    },
+    {
+      name: 'version',
+      type: 'number',
+      default: '-',
+      example: () => (<code>1234</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/advanced_url_delivery_options#asset_versions">More Info</a>)
+    },
+  ]}
+/>
+
+#### `assetType`
+
+Configures the asset type for the delivered resource.
+
+This defaults to an image for the getCldImageUrl helper.
+
+**Examples**
+
+Create an image thumbnail from a video asset:
+
+```jsx copy
+assetType: 'video'
+```
+
+[Learn more about Asset Types](https://cloudinary.com/documentation/image_transformations#transformation_url_structure) on the Cloudinary docs.
+
+
+#### `config`
+
+Allows configuration for the Cloudinary environment.
+
+**Examples**
+
+```jsx copy
+config: {
+  cloud: {
+    cloudName: 'my-cloud'
+  }
+}
+```
+
+[Learn more about configuration parameters](https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters) on the Cloudinary docs.
+
+#### `deliveryType`
+
+Controls the delivery type of the image.
+
+**Examples**
+
+```jsx copy
+deliveryType: 'fetch'
+```
+
+[Learn more about Delivery Types](https://cloudinary.com/documentation/image_transformations#delivery_types) on the Cloudinary docs.
+
+#### `defaultImage`
+
+Configures the default image to use in case the given public ID is not available.
+
+<Callout emoji={false} type="info">
+  `defaultImage` must include a format / file extension.
+</Callout>
+
+**Examples**
+
+```jsx copy
+defaultImage: 'myimage.jpg'
+```
+
+[Learn more about Default Images](https://cloudinary.com/documentation/transformation_reference#d_default_image) on the Cloudinary docs.
+
+#### `flags`
+
+Alters the regular behavior of another transformation or the overall delivery behavior.
+
+<Callout emoji={false}>
+  The `keep_iptc` flag requires not including a quality of auto. Using `quality="default"` avoids setting the quality flag in the URL.
+</Callout>
+
+**Examples**
+
+```jsx copy
+flags: ['keep_iptc'],
+quality: 'default'
+```
+
+[Learn more about Flags](https://cloudinary.com/documentation/transformation_reference#fl_flag) on the Cloudinary docs.
+
+#### `seoSuffix`
+
+Adds a dynamic, descriptive suffix to the Public ID for greater SEO control of image URLs.
+
+**Examples**
+
+```jsx copy
+seoSuffix: 'jellyfish-in-space'
+```
+
+[Learn more about Dynamic SEO Suffixes](https://cloudinary.com/documentation/advanced_url_delivery_options#dynamic_seo_suffixes) on the Cloudinary docs.
+
+#### `version`
+
+Controls the version defined in the delivery URL.
+
+**Examples**
+
+```jsx copy
+version: '1234'
+```
+
+[Learn more about Asset Versions](https://cloudinary.com/documentation/advanced_url_delivery_options#asset_versions) on the Cloudinary docs.
+
+### Managing Transformations
+
+Most transformations and effects are exposed as top-level props to enable you to easily
+apply what you need, but you can also use the following props for more advanced and
+organized ways of applying transformations and effects.
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'default',
+      title: 'Default'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    }
+  ]}
+  data={[
+    {
+      name: 'effects',
+      type: 'array',
+      default: '-',
+      example: () => (<code>{`[{ background: 'blue' }]`}</code>)
+    },
+    {
+      name: 'namedTransformations',
+      type: 'string | array',
+      default: '-',
+      example: () => (<code>{`['my-named-transformation']`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/image_transformations#named_transformations">More Info</a>)
+    },
+    {
+      name: 'preserveTransformations',
+      type: 'string',
+      default: () => (<code>false</code>),
+      example: () => (<code>true</code>)
+    },
+    {
+      name: 'rawTransformations',
+      type: 'array',
+      default: '-',
+      example: () => (<code>{`['e_blur:2000']`}</code>),
+    },
+    {
+      name: 'strictTransformations',
+      type: 'boolean',
+      default: '-',
+      example: () => (<a href="#stricttransformations">Strict Transformations</a>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/control_access_to_media#strict_transformations">More Info</a>)
+    },
+    {
+      name: 'transformations (deprecated)',
+      type: 'string | array',
+      default: '-',
+      example: () => (<code>{`['my-named-transformation']`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/image_transformations#named_transformations">More Info</a>)
+    },
+  ]}
+/>
+
+#### `effects`
+
+Applies a chain of transformation sets to an image.
+
+**Examples**
+
+```jsx copy
+effects: [
+  {
+    width: 100,
+    height: 100,
+    crop: 'fill'
+  },
+  {
+    opacity: 50
+  }
+]
+```
+
+#### `namedTransformations`
+
+Applies named transformations to the image.
+
+**Examples**
+
+```jsx copy
+namedTransformations: ['my-transformation']
+```
+
+[Learn more about Named Transformations](https://cloudinary.com/documentation/image_transformations#named_transformations) on the Cloudinary docs.
+
+
+#### `preserveTransformations`
+
+Preserves transformations already applied to an image when passing in a Cloudinary URL
+as the `src`.
+
+**Examples**
+
+```jsx copy
+preserveTransformations: true
+```
+
+#### `rawTransformations`
+
+Provides the ability to pass in an array of "raw" Cloudinary transformations using the
+[Transformation URL API](https://cloudinary.com/documentation/transformation_reference)
+
+**Examples**
+
+```jsx copy
+rawTransformations: ['w_100', 'b_blue', 'f_auto']
+```
+
+#### `strictTransformations`
+
+[Strict Transformations](https://cloudinary.com/documentation/control_access_to_media#strict_transformations) gives
+you the ability to have more control over what transformations are permitted to be used from your Cloudinary account.
+
+By enabling Strict Transformations, you restrict the ability to generate transformations on-the-fly requiring explicit
+approval through the Cloudinary dashboard.
+
+> Note: This disables [optimization](#optimization) and [responsive sizing](/guides/responsive-images)
+only allowing [named transformations](#transformations) to be applied. The width and height are not applied to the URL,
+but are still included on the image tag rendered to the DOM.
+
+**Examples**
+
+```jsx copy
+strictTransformations: true,
+transformations: ['my-transformation']
+```
+
+[Learn more about Strict Transformations](https://cloudinary.com/documentation/control_access_to_media#strict_transformations) on the Cloudinary docs.
+
+#### `transformations` - Deprecated
+
+**Use namedTransformations instead**
+
+### Optimization
+
+By default, getCldImageUrl opts in any image to `f_auto` and `q_auto` which provide automatic
+optimization through intelligent compression and by automatically delivering the most
+efficient format based on the browser and device requesting the image.
+
+You can customize and manage these properties using the options below:
+
+<Table
+  columns={[
+    {
+      id: 'name',
+      title: 'Name'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'default',
+      title: 'Default'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    }
+  ]}
+  data={[
+    {
+      name: 'dpr',
+      type: 'number/string',
+      default: '-',
+      example: () => (<code>2.0</code>),
+      more: () => (<a className="whitespace-nowrap" href="asdf">More Info</a>)
+    },
+    {
+      name: 'format',
+      type: 'string',
+      default: () => (<code>auto</code>),
+      example: () => (<code>webp</code>),
+      more: () => (<a className="whitespace-nowrap" href="asdf">More Info</a>)
+    },
+    {
+      name: 'quality',
+      type: 'string',
+      default: () => (<code>auto</code>),
+      example: () => (<code>90</code>),
+      more: () => (<a className="whitespace-nowrap" href="asdf">More Info</a>)
+    },
+    {
+      name: 'unoptimized',
+      type: 'boolean',
+      default: '-',
+      example: () => (<a href="#unoptimized">Unoptimized Images</a>),
+      more: () => (<a className="whitespace-nowrap" href="asdf">More Info</a>)
+    },
+  ]}
+/>
+
+#### `dpr`
+
+Sets the device pixel ratio (DPR) for the delivered image or video using a specified value or automatically based on the requesting device.
+
+**Examples**
+
+```jsx copy
+dpr: '2.0'
+```
+
+[Learn more about configuring DPR](https://cloudinary.com/documentation/transformation_reference#dpr_dpr) on the Cloudinary docs.
+
+
+#### `format`
+
+Converts (if necessary) and delivers an asset in the specified format regardless of the file extension used in the delivery URL.
+
+**Examples**
+
+```jsx copy
+format: 'png'
+```
+
+[Learn more about format](https://cloudinary.com/documentation/transformation_reference#f_format) on the Cloudinary docs.
+
+
+#### `quality`
+
+Controls the quality of the delivered asset. Reducing the quality is a trade-off between visual quality and file size.
+
+**Examples**
+
+```jsx copy
+quality: 10
+```
+
+[Learn more about quality](https://cloudinary.com/documentation/transformation_reference#q_quality) on the Cloudinary docs.

--- a/docs/pages/getcldimageurl/examples.mdx
+++ b/docs/pages/getcldimageurl/examples.mdx
@@ -5,7 +5,8 @@ import { CldImage } from '../../../next-cloudinary';
 import { getCldImageUrl } from '../../../next-cloudinary';
 
 import OgImage from '../../components/OgImage';
-import ImageGrid from '../../components/ImageGrid';
+import HeaderImage from '../../components/HeaderImage';
+import CodeBlock from '../../components/CodeBlock';
 
 <Head>
   <title>getCldImageUrl Examples - Next Cloudinary</title>
@@ -24,91 +25,154 @@ import ImageGrid from '../../components/ImageGrid';
   The below examples use the CldImage component to render the images. This is not required, you can use the URL returned by getCldImageUrl in any way you like.
 </Callout>
 
-<ImageGrid>
-  <li>
-    <CldImage
-      src={getCldImageUrl({
-        src: `${process.env.IMAGES_DIRECTORY}/turtle`,
-        width: 960,
-        height: 600,
-      })}
-      width="960"
-      height="600"
-      sizes="(max-width: 480px) 100vw, 50vw"
-      alt=""
-      preserveTransformations
-    />
+## Basic Transformations
 
-    ### Basic
+Cloudinary supports a wide variety of powerful transformations that allow you to
+not only deliver, but easily edit and build new images on the fly.
 
-    ```js copy
-    getCldImageUrl({
-      src: 'images/turtle',
-      width: 960,
+### Background Removal
+
+#### Remove Background
+
+`removeBackground`: Removes the background of the image using AI
+
+<HeaderImage>
+  <CldImage
+    width="960"
+    height="600"
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
+    sizes="100vw"
+    removeBackground
+    alt=""
+  />
+</HeaderImage>
+
+<CodeBlock>
+  ```jsx copy showLineNumbers
+  import { getCldImageUrl } from 'next-cloudinary';
+
+  getCldImageUrl({
+    src: '<Your Public ID>',
+    width: 960,
+    height: 600,
+    removeBackground: true
+  })
+  ```
+</CodeBlock>
+
+<Callout emoji={false} type="info">
+  The Cloudinary AI Background Removal add-on is required to use this feature.
+</Callout>
+
+### Cropping & Resizing
+
+#### Cropping
+
+`crop`: Specifies the mode to use when cropping an image based on the given dimensions.
+
+> Note: By default, CldImage uses a gravity of auto, meaning the crop will automatically
+position the subject in the center of the resulting image.
+
+<HeaderImage>
+  <CldImage
+    width="300"
+    height="300"
+    src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
+    sizes="100vw"
+    crop="fill"
+    alt=""
+  />
+</HeaderImage>
+
+<CodeBlock>
+  ```jsx copy showLineNumbers
+  import { getCldImageUrl } from 'next-cloudinary';
+
+  getCldImageUrl({
+    src: '<Your Public ID>',
+    width: 300,
+    height: 300,
+    crop: 'fill'
+  })
+  ```
+</CodeBlock>
+
+Cloudinary additionally supports dynamic crop modes like `thumb` that
+may provide a different result based on the given width and height. To
+help provide more options for controlling cropping images, you can specify
+and object or array of objects.
+
+For instance, to crop the original source image, which will then later
+resize it to the initial width and height, you can use:
+
+<HeaderImage>
+  <CldImage
+    width="300"
+    height="300"
+    src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
+    sizes="100vw"
+    crop={{
+      width: 600,
       height: 600,
-    })
-    ```
-  </li>
-  <li>
-    <CldImage
-      src={getCldImageUrl({
-        src: `${process.env.IMAGES_DIRECTORY}/turtle`,
-        width: 960,
-        height: 600,
-        removeBackground: true
-      })}
-      width="960"
-      height="600"
-      sizes="(max-width: 480px) 100vw, 50vw"
-      alt=""
-      preserveTransformations
-    />
+      type: 'thumb',
+      source: true
+    }}
+    alt=""
+  />
+</HeaderImage>
 
-    ### Background Removal
+<CodeBlock>
+  ```jsx copy showLineNumbers
+  import { getCldImageUrl } from 'next-cloudinary';
 
-    ```js copy
-    getCldImageUrl({
-      src: 'images/turtle',
-      width: 960,
+  getCldImageUrl({
+    src: '<Your Public ID>',
+    width: 300,
+    height: 300,
+    crop: {
+      width: 600,
       height: 600,
-      removeBackground: true
-    })
-    ```
+      type: 'thumb',
+      source: true
+    }
+  })
+  ```
+</CodeBlock>
 
-    <Callout emoji={false}>
-      Background removal requires the <a href="https://cloudinary.com/documentation/cloudinary_ai_background_removal_addon">Cloudinary AI Background Removal</a> Add-On
-    </Callout>
-  </li>
-  <li>
-    <CldImage
-      src={getCldImageUrl({
-        src: `${process.env.IMAGES_DIRECTORY}/woman-headphones`,
-        width: 960,
-        height: 600,
-        crop: 'pad',
-        fillBackground: true
-      })}
-      width="960"
-      height="600"
-      sizes="(max-width: 480px) 100vw, 50vw"
-      alt=""
-      preserveTransformations
-    />
+Which will provide a consistent crop for all rendered sizes.
 
-    ### Generative Fill
+Learn more about [cropping](/getcldimageurl/configuration#crop) and [responsive images](/guides/responsive-images).
 
-    ```js copy
-    getCldImageUrl({
-      src: 'images/woman-headphones',
-      width: 960,
-      height: 600, // Original 1440
-      crop: 'pad', // Returns the given size with padding
-      fillBackground: true // Uses AI to extend image
-    })
-    ```
+### Generative Fill
 
-    <Callout emoji={false}>
-      The generative fill transformation is currently in Beta. <a href="https://cloudinary.com/documentation/effects_and_artistic_enhancements#generative_fill">Learn more</a>.
-    </Callout>
-  </li>
-</ImageGrid>
+`fillBackground`: Fills the background of an image using Generative AI
+
+<HeaderImage>
+  <CldImage
+    src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
+    width="960"
+    height="600"
+    crop="pad"
+    fillBackground
+    alt=""
+    sizes="100vw"
+  />
+</HeaderImage>
+
+<CodeBlock>
+  ```jsx copy showLineNumbers
+  import { getCldImageUrl } from 'next-cloudinary';
+
+  getCldImageUrl({
+    src: '<Your Public ID>',
+    width: 960,
+    height: 600,
+    fillBackground: true,
+    crop: 'pad'
+  })
+  ```
+</CodeBlock>
+
+<Callout emoji={false}>
+  The generative fill transformation is currently in Beta. <a href="https://cloudinary.com/documentation/transformation_reference#b_gen_fill">Learn more</a>.
+</Callout>

--- a/docs/pages/getcldogimageurl/examples.mdx
+++ b/docs/pages/getcldogimageurl/examples.mdx
@@ -8,6 +8,7 @@ import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../../next-cloudinary/src/co
 import OgImage from '../../components/OgImage';
 import HeaderImage from '../../components/HeaderImage';
 import CodeBlock from '../../components/CodeBlock';
+import ExamplesCldOgImage from '../../components/ExamplesCldOgImage';
 
 <Head>
   <title>getCldOgImageUrl Examples - Next Cloudinary</title>
@@ -31,15 +32,8 @@ import CodeBlock from '../../components/CodeBlock';
 `src`: The public ID of the image to use as a Social Card
 
 <HeaderImage>
-  <CldImage
-    src={getCldOgImageUrl({
-      src: `${process.env.IMAGES_DIRECTORY}/galaxy`,
-    })}
-    width={OG_IMAGE_WIDTH}
-    height={OG_IMAGE_HEIGHT}
-    sizes="(max-width: 480px) 100vw, 50vw"
-    alt=""
-    preserveTransformations
+  <ExamplesCldOgImage
+    src={`${process.env.IMAGES_DIRECTORY}/galaxy`}
   />
 </HeaderImage>
 
@@ -73,17 +67,10 @@ import CodeBlock from '../../components/CodeBlock';
 `underlay`: The public ID of the image to use as the new background.
 
 <HeaderImage>
-  <CldImage
-    src={getCldOgImageUrl({
-      src: `${process.env.IMAGES_DIRECTORY}/turtle`,
-      removeBackground: true,
-      underlay: `${process.env.IMAGES_DIRECTORY}/galaxy`,
-    })}
-    width={OG_IMAGE_WIDTH}
-    height={OG_IMAGE_HEIGHT}
-    sizes="(max-width: 480px) 100vw, 50vw"
-    alt=""
-    preserveTransformations
+  <ExamplesCldOgImage
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
+    removeBackground
+    underlay={`${process.env.IMAGES_DIRECTORY}/galaxy`}
   />
 </HeaderImage>
 
@@ -121,16 +108,16 @@ import CodeBlock from '../../components/CodeBlock';
 `text`: Adds basic text to the image
 
 <HeaderImage>
-  <CldImage
-    src={getCldOgImageUrl({
-      src: `${process.env.IMAGES_DIRECTORY}/white`,
-      text: 'Next Cloudinary'
-    })}
-    width={OG_IMAGE_WIDTH}
-    height={OG_IMAGE_HEIGHT}
-    sizes="(max-width: 480px) 100vw, 50vw"
-    alt=""
-    preserveTransformations
+  <ExamplesCldOgImage
+    src={`${process.env.IMAGES_DIRECTORY}/white`}
+    overlays={[{
+      text: {
+        fontFamily: 'Source Sans Pro',
+        fontSize: 120,
+        fontWeight: 'bold',
+        text: 'Next Cloudinary'
+      }
+    }]}
   />
 </HeaderImage>
 
@@ -141,7 +128,14 @@ import CodeBlock from '../../components/CodeBlock';
 
   const url = getCldOgImageUrl({
     src: '<Your Public ID>',
-    text: 'Next Cloudinary'
+    overlays: [{
+      text: {
+        fontFamily: 'Source Sans Pro',
+        fontSize: 120,
+        fontWeight: 'bold',
+        text: 'Next Cloudinary'
+      }
+    }]
   })
 
   export const metadata: Metadata = {

--- a/docs/pages/guides/responsive-images.mdx
+++ b/docs/pages/guides/responsive-images.mdx
@@ -1,8 +1,11 @@
 import Head from 'next/head';
-
-import OgImage from '../../components/OgImage';
+import { Callout } from 'nextra-theme-docs';
 
 import { CldImage } from '../../../next-cloudinary';
+
+import OgImage from '../../components/OgImage';
+import HeaderImage from '../../components/HeaderImage';
+import CodeBlock from '../../components/CodeBlock';
 
 <Head>
   <title>Responsive Images - Next Cloudinary</title>
@@ -17,66 +20,265 @@ import { CldImage } from '../../../next-cloudinary';
 
 # Responsive Images
 
-The [CldImage](/cldimage/basic-usage) component takes advantage of responsive images generated using the [Next Image component](https://nextjs.org/docs/api-reference/next/image).
+Responsive images are critical for page performance and they're made easy with
+the [CldImage](/cldimage/basic-usage) component.
 
-Using the `sizes` prop, you can configure exactly the sizes you need for your application, such as a similar example to the Next.js docs:
+The CldImage component takes advantage of responsive images generated using
+the [Next Image component](https://nextjs.org/docs/api-reference/next/image)
+which allows you to simply specify the sizes you want and the component
+handles the rest.
+
+Using the `sizes` prop, you can configure exactly the sizes you need for your
+application, such as a similar example to the Next.js docs:
 
 
-```jsx copy
-<CldImage
-  ...
-  sizes="(max-width: 768px) 100vw,
+<HeaderImage>
+  <CldImage
+    width="960"
+    height="600"
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
+    sizes="(max-width: 768px) 100vw,
           (max-width: 1200px) 50vw,
           33vw"
-```
+    alt="Turtle"
+  />
+</HeaderImage>
 
-Which would give you roughly full width images on mobile, a 2-column layout on tablets, and 3-column layout on desktop views.
+<CodeBlock>
+```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
 
-To ensure that the responsive images can effectively determine all appropriate sizes for the images, use the actual image width and height when specifying the dimension props.
+  <CldImage
+    width="960"
+    height="600"
+    src="<Your Public ID>"
+    sizes="(max-width: 768px) 100vw,
+          (max-width: 1200px) 50vw,
+          33vw"
+    alt="Description"
+  />
+  ```
+</CodeBlock>
+
+This would give you roughly full width images on mobile, a 2-column layout on
+tablets, and 3-column layout on desktop views.
 
 ### Responsive Images & CldImage
 
-The only caveat to this is when using cropping modes in Cloudinary.
+The difference with the CldImage component is that it utilizes Cloudinary tech
+in order to provide the responsive sizing.
+
+In the example above, the output would look like:
+
+```
+<img
+  alt="Turtle"
+  loading="lazy"
+  width="960"
+  height="600"
+  decoding="async"
+  data-nimg="1"
+  style="color:transparent"
+  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+  srcset="
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_256/f_auto/q_auto/v1/<Public ID> 256w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_384/f_auto/q_auto/v1/<Public ID> 384w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_640/f_auto/q_auto/v1/<Public ID> 640w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_750/f_auto/q_auto/v1/<Public ID> 750w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_828/f_auto/q_auto/v1/<Public ID> 828w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_1080/f_auto/q_auto/v1/<Public ID> 1080w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_1200/f_auto/q_auto/v1/<Public ID> 1200w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_1920/f_auto/q_auto/v1/<Public ID> 1920w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_2048/f_auto/q_auto/v1/<Public ID> 2048w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_3840/f_auto/q_auto/v1/<Public ID> 3840w
+  "
+  src="https://res.cloudinary.com/<Cloud Name>/image/upload/c_limit,w_3840/f_auto/q_auto/v1/<Public ID>"
+>
+```
+
+Where the image is automatically generated on the fly with Cloudinary by passing
+in a URL parameter of `w_<width>`.
+
+### Upscaling Images
+
+By default, the CldImage component uses the `limit` crop mode which explicitly
+prevents Cloudinary from upscaling an image if the size is greater than the original
+and instead, opting for the browser to resize the image on its behalf.
+
+To allow Cloudinary to upscale the image and potentially produce blurry images,
+you can set the crop mode to `scale`.
+
+### Cropping & Resizing
+
+Part of the benefit of using Cloudinary is access to dynamic cropping and
+resizing modes.
 
 In an example such as:
 
-```jsx copy
-<CldImage
-  ...
-  width="600"
-  height="600"
-  sizes="(max-width: 480px) 100vw, 50vw"
-  crop="thumb"
-  gravity="faces"
-/>
+<HeaderImage>
+  <CldImage
+    width="960"
+    height="960"
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
+    crop="fill"
+    sizes="100vw"
+    alt="Turtle"
+  />
+</HeaderImage>
+
+<CodeBlock>
+```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
+
+  <CldImage
+    width="960"
+    height="960"
+    src="<Your Public ID>"
+    crop="fill"
+    sizes="100vw"
+    alt="Description"
+  />
+  ```
+</CodeBlock>
+
+Each image will be cropped to a 1:1 ratio represented by the width and height provided.
+
+As the underlaying Next Image component generates an image for each responsive size,
+Cloudinary will use those sizes when building the URL, for example:
+
 ```
-
-Using cropping, we're setting a width of 600px and a height of 600px, telling Cloudinary we want to take our original image, crop it to that size, then position the focal point to the face in the image detected using AI.
-
-From a responsive standpoint, we're stating that we want full width images on anything less than 480px and half-width images on anything above.
-
-The challenge here is when cropping the image, we're cropping it to 600px, which is smaller than some of the sizes we want to responsively serve. We don't want to responsively change that cropped size, otherwise we would change the cropping results due to the crop attempting to grab different portions of the image depending on the size.
-
-To avoid attempting to load upscaled images, resulting in blurry or grainy images as well as more bandwidth used on a device, any responsive size that is greater than the set width will not be generated and instead, we'll deliver an image at that size specifically (in this example, 600x600).
-
-For instance, in the above example, the resulting responsive image in the HTML may look like:
-
-```jsx copy
 <img
-  sizes="(max-width: 480px) 100vw, 50vw"
+  alt="Turtle"
+  loading="lazy"
+  width="960"
+  height="960"
+  decoding="async"
+  data-nimg="1"
+  style="color:transparent"
+  sizes="100vw"
   srcset="
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/c_scale,w_384/f_auto/q_auto/v1/images/woman-headphones 384w,
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 640w,
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 750w,
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 828w,
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 1080w,
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 1200w,
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 1920w,
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 2048w,
-    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 3840w
-  " ... />
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_640,h_640,g_auto/f_auto/q_auto/v1/<Public ID> 640w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_750,h_750,g_auto/f_auto/q_auto/v1/<Public ID> 750w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_828,h_828,g_auto/f_auto/q_auto/v1/<Public ID> 828w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_1080,h_1080,g_auto/f_auto/q_auto/v1/<Public ID> 1080w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_1200,h_1200,g_auto/f_auto/q_auto/v1/<Public ID> 1200w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_1920,h_1920,g_auto/f_auto/q_auto/v1/<Public ID> 1920w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_2048,h_2048,g_auto/f_auto/q_auto/v1/<Public ID> 2048w,
+    https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_3840,h_3840,g_auto/f_auto/q_auto/v1/<Public ID> 3840w
+  "
+  src="https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,w_3840,h_3840,g_auto/f_auto/q_auto/v1/<Public ID>"
+>
 ```
 
-Notice that all of the URLs are the same except for the first one, as it's smaller than 600px.
+And so on...
 
-When the browser attempts to load these responsive images, it will effectively ignore the same URLs, only having loaded it once if resizing the browser.
+### Dynamic Cropping Modes
+
+While some cropping modes will "just work" with responsive sizing, others won't.
+
+For instance, the crop mode of `thumb` will dynamically crop an image based on its
+size and contents, meaning the resulting crop of a 256x256 image may be different
+than a 640x640 image.
+
+<HeaderImage>
+  <CldImage
+    width="960"
+    height="960"
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
+    crop="thumb"
+    sizes="100vw"
+    alt="Turtle"
+  />
+</HeaderImage>
+
+<CodeBlock>
+```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
+
+  <CldImage
+    width="960"
+    height="960"
+    src="<Your Public ID>"
+    crop="thumb"
+    sizes="100vw"
+    alt="Description"
+  />
+  ```
+</CodeBlock>
+
+The resulting transformations may look like:
+
+```
+.../w_256,h_256,c_thumb/...
+.../w_384,h_384,c_thumb/...
+.../w_640,h_640,c_thumb/...
+.../w_750,h_750,c_thumb/...
+```
+
+<Callout emoji={false} type="info">
+  Try resizing the browser to very small, refresh the page, then increase
+  the browser size to see the differences.
+</Callout>
+
+This produces inconsistent results depending on the size of the device, which isn't
+a great experience.
+
+To help give visitors that great experience, we can crop our image in two stages
+opting to crop an image before any transformations are made, then allowing the
+responsive sizing to resize the result.
+
+<HeaderImage>
+  <CldImage
+    width="960"
+    height="960"
+    src={`${process.env.IMAGES_DIRECTORY}/turtle`}
+    crop={{
+      type: 'thumb',
+      source: true
+    }}
+    sizes="100vw"
+    alt="Turtle"
+  />
+</HeaderImage>
+
+<CodeBlock>
+```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
+
+  <CldImage
+    width="960"
+    height="960"
+    src="<Your Public ID>"
+    crop={{
+      type: 'thumb',
+      source: true
+    }}
+    sizes="100vw"
+    alt="Description"
+  />
+  ```
+</CodeBlock>
+
+<Callout emoji={false}>
+  Tip: By default, using an object for `crop` will derive the width and
+  height from the top-level width and height, but you can customize those
+  values by explicitly setting them.
+</Callout>
+
+The resulting transformations may look like:
+
+```
+.../w_960,h_960,c_thumb/<Other Transformations>/w_256,h_256,c_limit/...
+.../w_960,h_960,c_thumb/<Other Transformations>/w_384,h_384,c_limit/...
+.../w_960,h_960,c_thumb/<Other Transformations>/w_640,h_640,c_limit/...
+.../w_960,h_960,c_thumb/<Other Transformations>/w_750,h_750,c_limit/...
+```
+
+<Callout emoji={false} type="info">
+  Try resizing the browser to very small, refresh the page, then increase
+  the browser size to see it is now consistent.
+</Callout>
+
+By using object-syntax for the crop prop and setting `source` to `true`, we 
+are specifying that we want the crop transformation to be applied to the
+source image.

--- a/docs/pages/guides/social-media-card.mdx
+++ b/docs/pages/guides/social-media-card.mdx
@@ -2,8 +2,9 @@ import Head from 'next/head';
 import { Callout, Tab, Tabs } from 'nextra-theme-docs';
 
 import OgImage from '../../components/OgImage';
-
-import { CldImage, CldOgImage } from '../../../next-cloudinary';
+import HeaderImage from '../../components/HeaderImage';
+import CodeBlock from '../../components/CodeBlock';
+import ExamplesCldOgImage from '../../components/ExamplesCldOgImage';
 
 <Head>
   <title>Social Media Cards - Next Cloudinary</title>
@@ -18,23 +19,17 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
 
 # Generating Social Media Cards
 
-<Callout emoji={false}>
-  CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. The following examples make use of the `<CldImage>` tag to showcase what's possible.
-</Callout>
+You can use Next Cloudinary to easily generate dynamic social media cards
+for your Next.js app.
 
 ## Example
 
-<div style={{ maxWidth: 500, margin: '0 auto' }}>
-  <CldImage
-    width="2400"
-    height="1200"
-    crop="fill"
-    gravity="auto"
+<HeaderImage>
+  <ExamplesCldOgImage
     src={`${process.env.IMAGES_DIRECTORY}/white`}
-    sizes="100w"
     overlays={[
       {
-        publicId: 'images/mountain',
+        publicId: `${process.env.IMAGES_DIRECTORY}/mountain`,
         position: {
           x: 0,
           y: 0,
@@ -44,168 +39,176 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
           {
             crop: 'fill',
             gravity: 'auto',
-            width: 800,
-            height: 1200
+            width: '0.33',
+            height: '1.0'
           }
-        ]
+        ],
+        flags: ['relative']
       },
       {
-        width: 1400,
-        crop: 'fit',
-        text: {
-          color: 'black',
-          fontFamily: 'Source Sans Pro',
-          fontSize: 160,
-          fontWeight: 'bold',
-          text: 'Next Cloudinary'
-        },
-        position: {
-          x: 100,
-          y: -100,
-          gravity: 'west',
-        },
-      },
-      {
-        width: 1400,
+        width: 700,
         crop: 'fit',
         text: {
           color: 'black',
           fontFamily: 'Source Sans Pro',
           fontSize: 80,
+          fontWeight: 'bold',
+          text: 'Next Cloudinary'
+        },
+        position: {
+          x: 80,
+          y: -50,
+          gravity: 'west',
+        },
+      },
+      {
+        width: 700,
+        crop: 'fit',
+        text: {
+          color: 'black',
+          fontFamily: 'Source Sans Pro',
+          fontSize: 40,
           text: 'Get the power of Cloudinary in a Next.js project with Next Cloudinary!'
         },
         position: {
-          x: 100,
-          y: 100,
+          x: 80,
+          y: 50,
           gravity: 'west',
         },
       },
     ]}
-    alt="Next Cloudinary with picture of a mountain"
   />
-</div>
+</HeaderImage>
 
+> CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. The following examples make use of the `<CldImage>` tag to showcase what's possible.
 
-<Tabs items={['CldOgImage (Pages)', 'getCldOgImageUrl (App)']}>
+<Tabs items={['getCldOgImageUrl (App)', 'CldOgImage (Pages)']}>
   <Tab>
-    ```jsx copy
-    import { CldOgImage } from 'next-cloudinary';
+    <CodeBlock>
+    ```jsx copy showLineNumbers
+      import { getCldOgImageUrl } from 'next-cloudinary';
 
-    <CldOgImage
-      src="images/white"
-      overlays={[
-        {
-          publicId: 'images/mountain',
-          position: {
-            x: 0,
-            y: 0,
-            gravity: 'north_east',
+      getCldOgImageUrl({
+        src: '<Your Public ID>',
+        overlays: [
+          {
+            publicId: '<Your Public ID>',
+            position: {
+              x: 0,
+              y: 0,
+              gravity: 'north_east',
+            },
+            effects: [
+              {
+                crop: 'fill',
+                gravity: 'auto',
+                width: '0.33',
+                height: '1.0'
+              }
+            ],
+            flags: ['relative']
           },
-          effects: [
-            {
-              crop: 'fill',
-              gravity: 'auto',
-              width: 800,
-              height: 1200
-            }
-          ]
-        },
-        {
-          width: 1400,
-          crop: 'fit',
-          text: {
-            color: 'black',
-            fontFamily: 'Source Sans Pro',
-            fontSize: 160,
-            fontWeight: 'bold',
-            text: 'Next Cloudinary'
+          {
+            width: 700,
+            crop: 'fit',
+            text: {
+              color: 'black',
+              fontFamily: 'Source Sans Pro',
+              fontSize: 80,
+              fontWeight: 'bold',
+              text: '<Your Text>'
+            },
+            position: {
+              x: 50,
+              y: -50,
+              gravity: 'west',
+            },
           },
-          position: {
-            x: 100,
-            y: -100,
-            gravity: 'west',
+          {
+            width: 700,
+            crop: 'fit',
+            text: {
+              color: 'black',
+              fontFamily: 'Source Sans Pro',
+              fontSize: 40,
+              text: '<Your Text>'
+            },
+            position: {
+              x: 50,
+              y: 50,
+              gravity: 'west',
+            },
           },
-        },
-        {
-          width: 1400,
-          crop: 'fit',
-          text: {
-            color: 'black',
-            fontFamily: 'Source Sans Pro',
-            fontSize: 80,
-            text: 'Get the power of Cloudinary in a Next.js project with Next Cloudinary!'
-          },
-          position: {
-            x: 100,
-            y: 100,
-            gravity: 'west',
-          },
-        },
-      ]}
-      twitterTitle="Next Cloudinary"
-      alt="Next Cloudinary with picture of a mountain"
-    />
+        ]
+      });
     ```
+    </CodeBlock>
   </Tab>
   <Tab>
-    ```jsx copy
-    import { getCldOgImageUrl } from 'next-cloudinary';
+    <CodeBlock>
+    ```jsx copy showLineNumbers
+      import { CldOgImage } from 'next-cloudinary';
 
-    getCldOgImageUrl({
-      src: 'images/white',
-      overlays: [
-        {
-          publicId: 'images/mountain',
-          position: {
-            x: 0,
-            y: 0,
-            gravity: 'north_east',
+      <CldOgImage
+        src="<Your Public ID>"
+        overlays={[
+          {
+            publicId: '<Your Public ID>',
+            position: {
+              x: 0,
+              y: 0,
+              gravity: 'north_east',
+            },
+            effects: [
+              {
+                crop: 'fill',
+                gravity: 'auto',
+                width: '0.33',
+                height: '1.0'
+              }
+            ],
+            flags: ['relative']
           },
-          effects: [
-            {
-              crop: 'fill',
-              gravity: 'auto',
-              width: 800,
-              height: 1200
-            }
-          ]
-        },
-        {
-          width: 1400,
-          crop: 'fit',
-          text: {
-            color: 'black',
-            fontFamily: 'Source Sans Pro',
-            fontSize: 160,
-            fontWeight: 'bold',
-            text: 'Next Cloudinary'
+          {
+            width: 700,
+            crop: 'fit',
+            text: {
+              color: 'black',
+              fontFamily: 'Source Sans Pro',
+              fontSize: 80,
+              fontWeight: 'bold',
+              text: '<Your Text>'
+            },
+            position: {
+              x: 80,
+              y: -50,
+              gravity: 'west',
+            },
           },
-          position: {
-            x: 100,
-            y: -100,
-            gravity: 'west',
+          {
+            width: 700,
+            crop: 'fit',
+            text: {
+              color: 'black',
+              fontFamily: 'Source Sans Pro',
+              fontSize: 40,
+              text: '<Your Text>'
+            },
+            position: {
+              x: 80,
+              y: 50,
+              gravity: 'west',
+            },
           },
-        },
-        {
-          width: 1400,
-          crop: 'fit',
-          text: {
-            color: 'black',
-            fontFamily: 'Source Sans Pro',
-            fontSize: 80,
-            text: 'Get the power of Cloudinary in a Next.js project with Next Cloudinary!'
-          },
-          position: {
-            x: 100,
-            y: 100,
-            gravity: 'west',
-          },
-        },
-      ]
-    });
+        ]}
+        twitterTitle="<Your Text>"
+        alt="<Your Text>"
+      />
     ```
+    </CodeBlock>
   </Tab>
 </Tabs>
 
 ## Learn More
+* [Social Media Card Templates](/templates/social-media-cards)
 * [CldOgImage Configuration](/cldogimage/configuration)

--- a/docs/pages/guides/text-overlays.mdx
+++ b/docs/pages/guides/text-overlays.mdx
@@ -2,6 +2,8 @@ import Head from 'next/head';
 import { Tab, Tabs } from 'nextra-theme-docs';
 
 import OgImage from '../../components/OgImage';
+import HeaderImage from '../../components/HeaderImage';
+import CodeBlock from '../../components/CodeBlock';
 
 import { CldImage } from '../../../next-cloudinary';
 
@@ -22,97 +24,140 @@ You can add text on top of your image with text-based overlays.
 
 ## Example
 
-<div style={{ maxWidth: 500, margin: '0 auto' }}>
+<HeaderImage>
   <CldImage
     width="1335"
     height="891"
     src={`${process.env.IMAGES_DIRECTORY}/sneakers`}
     sizes="100vw"
-    overlays={[{
-      width: 2670 - 20,
-      crop: 'fit',
-      position: {
-        x: 140,
-        y: 140,
-        angle: -20,
-        gravity: 'south_east',
+    overlays={[
+      {
+        position: {
+          x: 160,
+          y: 120,
+          angle: -20,
+          gravity: 'south_east',
+        },
+        text: {
+          color: 'magenta',
+          fontFamily: 'Source Sans Pro',
+          fontSize: 280,
+          fontWeight: 'black',
+          text: 'WITH STYLE'
+        }
       },
-      text: {
-        color: 'blueviolet',
-        fontFamily: 'Source Sans Pro',
-        fontSize: 160,
-        fontWeight: 'bold',
-        textDecoration: 'underline',
-        letterSpacing: 14,
-        text: 'Cool Beans'
-      }
-    }]}
-    alt="Sneakers with Cool Beans"
+      {
+        position: {
+          x: 140,
+          y: 140,
+          angle: -20,
+          gravity: 'south_east',
+        },
+        text: {
+          color: 'white',
+          fontFamily: 'Source Sans Pro',
+          fontSize: 280,
+          fontWeight: 'black',
+          text: 'WITH STYLE'
+        }
+      },
+    ]}
+    alt="Sneakers with text With Style"
   />
-</div>
+</HeaderImage>
 
 <Tabs items={['CldImage', 'getCldImageUrl']}>
-  <Tab>
-    ```jsx copy
-    import { CldImage } from 'next-cloudinary';
+  <Tab className="nx-pt-0">
+    <CodeBlock>
+    ```jsx copy showLineNumbers
+      import { CldImage } from 'next-cloudinary';
 
-    <CldImage
-      width="1335"
-      height="891"
-      src="images/sneakers"
-      sizes="100vw"
-      overlays={[{
-        width: 2670 - 20,
-        crop: 'fit',
-        position: {
-          x: 140,
-          y: 140,
-          angle: -20,
-          gravity: 'south_east',
-        },
-        text: {
-          color: 'blueviolet',
-          fontFamily: 'Source Sans Pro',
-          fontSize: 160,
-          fontWeight: 'bold',
-          textDecoration: 'underline',
-          letterSpacing: 14,
-          text: 'Cool Beans'
-        }
-      }]}
-      alt="Sneakers with Cool Beans"
-    />
-    ```
+      <CldImage
+        width="1335"
+        height="891"
+        src="images/sneakers"
+        sizes="100vw"
+        overlays={[
+          {
+            position: {
+              x: 160,
+              y: 120,
+              angle: -20,
+              gravity: 'south_east',
+            },
+            text: {
+              color: 'magenta',
+              fontFamily: 'Source Sans Pro',
+              fontSize: 280,
+              fontWeight: 'black',
+              text: 'WITH STYLE'
+            }
+          },
+          {
+            position: {
+              x: 140,
+              y: 140,
+              angle: -20,
+              gravity: 'south_east',
+            },
+            text: {
+              color: 'white',
+              fontFamily: 'Source Sans Pro',
+              fontSize: 280,
+              fontWeight: 'black',
+              text: 'WITH STYLE'
+            }
+          },
+        ]}
+        alt="Sneakers with text With Style"
+      />
+      ```
+    </CodeBlock>
   </Tab>
   <Tab>
-    ```jsx copy
-    import { getCldImageUrl } from 'next-cloudinary';
+    <CodeBlock>
+    ```jsx copy showLineNumbers
+      import { getCldImageUrl } from 'next-cloudinary';
 
-    getCldImageUrl({
-      width: 1335,
-      height: 891,
-      src: 'images/sneakers',
-      overlays: [{
-        width: 2670 - 20,
-        crop: 'fit',
-        position: {
-          x: 140,
-          y: 140,
-          angle: -20,
-          gravity: 'south_east',
-        },
-        text: {
-          color: 'blueviolet',
-          fontFamily: 'Source Sans Pro',
-          fontSize: 160,
-          fontWeight: 'bold',
-          textDecoration: 'underline',
-          letterSpacing: 14,
-          text: 'Cool Beans'
-        }
-      }]
-    })
-    ```
+      getCldImageUrl({
+        width: 1335,
+        height: 891,
+        src: 'images/sneakers',
+        overlays: [
+          {
+            position: {
+              x: 160,
+              y: 120,
+              angle: -20,
+              gravity: 'south_east',
+            },
+            text: {
+              color: 'magenta',
+              fontFamily: 'Source Sans Pro',
+              fontSize: 280,
+              fontWeight: 'black',
+              text: 'WITH STYLE'
+            }
+          },
+          {
+            position: {
+              x: 140,
+              y: 140,
+              angle: -20,
+              gravity: 'south_east',
+            },
+            text: {
+              color: 'white',
+              fontFamily: 'Source Sans Pro',
+              fontSize: 280,
+              fontWeight: 'black',
+              text: 'WITH STYLE'
+            }
+          },
+        ]
+      })
+      ```
+    </CodeBlock>
   </Tab>
 </Tabs>
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -31,24 +31,99 @@ High-performance image and video delivery and uploading at scale in Next.js powe
 
 
 <ImageGrid>
+
   <li>
+    { /** Crops at the end - not usually what you want with responsive sizing */ }
     <CldImage
       width="987"
-      height="1481"
+      height="987"
       src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
+      crop="fill"
+      alt=""
       sizes="50vw"
-      alt="Original image of woman with headphones"
-      priority
     />
   </li>
+  <li>
+    { /** Crops at the beginning - but awkward syntax */ }
+    <CldImage
+      width="987"
+      height="987"
+      src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
+      baseWidth="987"
+      baseHeight="987"
+      baseCrop="thumb"
+      alt=""
+      sizes="50vw"
+    />
+  </li>
+
+
+
+
   <li>
     <CldImage
       width="987"
       height="987"
       src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
       sizes="50vw"
-      crop="thumb"
-      gravity="faces"
+      baseWidth="987"
+      baseHeight="987"
+      baseCrop="thumb"
+      baseGravity="faces"
+      removeBackground
+      tint="40:253f8c"
+      underlay={`${process.env.IMAGES_DIRECTORY}/city-skyline`}
+      overlays={[
+        {
+          position: {
+            gravity: 'north',
+            y: 60
+          },
+          text: {
+            color: 'rgb:52a4ff80',
+            fontFamily: 'Source Sans Pro',
+            fontSize: 320,
+            fontWeight: 'black',
+            text: 'MUSIC',
+            letterSpacing: -10,
+            lineSpacing: -100,
+            stroke: true,
+            border: '20px_solid_rgb:2d0eff99',
+          }
+        },
+        {
+          position: {
+            gravity: 'south',
+            y: 60
+          },
+          text: {
+            color: 'rgb:52a4ff80',
+            fontFamily: 'Source Sans Pro',
+            fontSize: 320,
+            fontWeight: 'black',
+            text: 'IS LIFE',
+            letterSpacing: -10,
+            lineSpacing: -100,
+            stroke: true,
+            border: '20px_solid_rgb:2d0eff99',
+          }
+        }
+      ]}
+      alt="Image of woman with headphones transformed with Cloudinary"
+      priority
+    />
+
+
+
+    <CldImage
+      width="987"
+      height="987"
+      src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
+      sizes="50vw"
+      baseWidth="987"
+      baseHeight="987"
+      baseCrop="thumb"
+      baseGravity="faces"
       removeBackground
       tint="40:253f8c"
       underlay={`${process.env.IMAGES_DIRECTORY}/city-skyline`}

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -31,99 +31,29 @@ High-performance image and video delivery and uploading at scale in Next.js powe
 
 
 <ImageGrid>
-
-  <li>
-    { /** Crops at the end - not usually what you want with responsive sizing */ }
-    <CldImage
-      width="987"
-      height="987"
-      src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
-      crop="fill"
-      alt=""
-      sizes="50vw"
-    />
-  </li>
-  <li>
-    { /** Crops at the beginning - but awkward syntax */ }
-    <CldImage
-      width="987"
-      height="987"
-      src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
-      baseWidth="987"
-      baseHeight="987"
-      baseCrop="thumb"
-      alt=""
-      sizes="50vw"
-    />
-  </li>
-
-
-
-
   <li>
     <CldImage
       width="987"
       height="987"
       src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
       sizes="50vw"
-      baseWidth="987"
-      baseHeight="987"
-      baseCrop="thumb"
-      baseGravity="faces"
-      removeBackground
-      tint="40:253f8c"
-      underlay={`${process.env.IMAGES_DIRECTORY}/city-skyline`}
-      overlays={[
-        {
-          position: {
-            gravity: 'north',
-            y: 60
-          },
-          text: {
-            color: 'rgb:52a4ff80',
-            fontFamily: 'Source Sans Pro',
-            fontSize: 320,
-            fontWeight: 'black',
-            text: 'MUSIC',
-            letterSpacing: -10,
-            lineSpacing: -100,
-            stroke: true,
-            border: '20px_solid_rgb:2d0eff99',
-          }
-        },
-        {
-          position: {
-            gravity: 'south',
-            y: 60
-          },
-          text: {
-            color: 'rgb:52a4ff80',
-            fontFamily: 'Source Sans Pro',
-            fontSize: 320,
-            fontWeight: 'black',
-            text: 'IS LIFE',
-            letterSpacing: -10,
-            lineSpacing: -100,
-            stroke: true,
-            border: '20px_solid_rgb:2d0eff99',
-          }
-        }
-      ]}
       alt="Image of woman with headphones transformed with Cloudinary"
       priority
     />
-
-
-
+  </li>
+  <li>
     <CldImage
       width="987"
       height="987"
       src={`${process.env.IMAGES_DIRECTORY}/woman-headphones`}
       sizes="50vw"
-      baseWidth="987"
-      baseHeight="987"
-      baseCrop="thumb"
-      baseGravity="faces"
+      crop={{
+        width: 987,
+        height: 987,
+        crop: 'thumb',
+        gravity: 'faces',
+        source: true,
+      }}
       removeBackground
       tint="40:253f8c"
       underlay={`${process.env.IMAGES_DIRECTORY}/city-skyline`}

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -50,7 +50,7 @@ High-performance image and video delivery and uploading at scale in Next.js powe
       crop={{
         width: 987,
         height: 987,
-        crop: 'thumb',
+        type: 'thumb',
         gravity: 'faces',
         source: true,
       }}

--- a/docs/pages/templates/social-media-cards.mdx
+++ b/docs/pages/templates/social-media-cards.mdx
@@ -4,8 +4,7 @@ import { Callout, Tab, Tabs } from 'nextra-theme-docs';
 import OgImage from '../../components/OgImage';
 import HeaderImage from '../../components/HeaderImage';
 import CodeBlock from '../../components/CodeBlock';
-
-import { CldImage, CldOgImage } from '../../../next-cloudinary';
+import ExamplesCldOgImage from '../../components/ExamplesCldOgImage';
 
 <Head>
   <title>Social Card Images - Next Cloudinary</title>
@@ -20,15 +19,13 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
 
 # Social Card Image Templates
 
+> CldOgImage does not render an `<img>` tag, meaning it can't be visually embedded on a page. The following examples make use of the `<CldImage>` tag to showcase what's possible.
+
 ## Article
 
 <HeaderImage>
-  <CldImage
-    width="2400"
-    height="1254"
-    crop="fill"
+  <ExamplesCldOgImage
     src={`${process.env.IMAGES_DIRECTORY}/galaxy`}
-    sizes="100w"
     effects={[
       {
         background: 'rgb:010A44'
@@ -44,68 +41,66 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
     overlays={[
       {
         publicId: `${process.env.IMAGES_DIRECTORY}/galaxy`,
-        width: 2400,
-        height: 1254,
+        width: 1200,
+        height: 630,
         crop: 'fill',
         effects: [
           { opacity: 20 }
         ]
       },
       {
-        width: 2000,
+        width: 1000,
         crop: 'fit',
         text: {
           color: 'white',
           fontFamily: 'Merriweather',
-          fontSize: 116,
+          fontSize: 58,
           fontWeight: 'bold',
-          lineSpacing: 20,
-          lineSpacing: 20,
+          lineSpacing: 10,
+          lineSpacing: 10,
           text: 'High-Performance Image & Video Delivery at Scale in Next.js'
         },
         position: {
-          x: 200,
-          y: 200,
+          x: 100,
+          y: 100,
           gravity: 'north_west'
         },
       },
       {
         publicId: `${process.env.IMAGES_DIRECTORY}/galaxy`,
-        width: 2000,
-        height: 4,
+        width: 1000,
+        height: 2,
         effects: [{
           colorize: '100,co_white',
           opacity: 70
         }],
         position: {
-          x: 200,
-          y: 350,
+          x: 100,
+          y: 175,
           gravity: 'south_west'
         },
       },
       {
-        width: 120,
+        width: 60,
         crop: 'fit',
         publicId: `${process.env.IMAGES_DIRECTORY}/cloudinary-logo-white`,
         position: {
-          x: 200,
-          y: 205,
+          x: 100,
+          y: 102,
           gravity: 'south_west'
         },
       },
       {
-        width: 1400,
-        crop: 'fit',
         text: {
           color: 'white',
           fontFamily: 'Lato',
-          fontSize: 74,
+          fontSize: 37,
           fontWeight: 'bold',
           text: 'Next Cloudinary'
         },
         position: {
-          x: 360,
-          y: 200,
+          x: 180,
+          y: 100,
           gravity: 'south_west'
         },
       },
@@ -122,7 +117,7 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
     > Note: you can alternatively use this function to pass dynamic values using the
     [generateMetadata function](https://nextjs.org/docs/app/api-reference/functions/generate-metadata).
 
-    <CodeBlock>
+    <CodeBlock className="mt-6">
       ```jsx copy showLineNumbers
       import { Metadata } from 'next';
       import { getCldOgImageUrl } from 'next-cloudinary';
@@ -139,7 +134,7 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
               // Prefer a different size? Be sure to update the width and height of the
               // metadata as well as the image configuration of getCldOgImageUrl
               width: 1200,
-              height: 627,
+              height: 630,
               url: getCldOgImageUrl({
                 src: publicId,
                 effects: [
@@ -157,68 +152,66 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
                 overlays: [
                   {
                     publicId,
-                    width: 2400,
-                    height: 1254,
+                    width: 1200,
+                    height: 630,
                     crop: 'fill',
                     effects: [
                       { opacity: 20 }
                     ]
                   },
                   {
-                    width: 2000,
+                    width: 1000,
                     crop: 'fit',
                     text: {
                       color: 'white',
-                      fontFamily: 'Lato',
-                      fontSize: 130,
-                      fontWeight: 'black',
-                      lineSpacing: 20,
-                      lineSpacing: 20,
+                      fontFamily: 'Merriweather',
+                      fontSize: 58,
+                      fontWeight: 'bold',
+                      lineSpacing: 10,
+                      lineSpacing: 10,
                       text: headline
                     },
                     position: {
-                      x: 200,
-                      y: 200,
+                      x: 100,
+                      y: 100,
                       gravity: 'north_west'
                     },
                   },
                   {
                     publicId,
-                    width: 2000,
-                    height: 4,
+                    width: 1000,
+                    height: 2,
                     effects: [{
                       colorize: '100,co_white',
                       opacity: 70
                     }],
                     position: {
-                      x: 200,
-                      y: 350,
+                      x: 100,
+                      y: 175,
                       gravity: 'south_west'
                     },
                   },
                   {
-                    width: 120,
+                    width: 60,
                     crop: 'fit',
                     publicId: logoPublicId,
                     position: {
-                      x: 200,
-                      y: 205,
+                      x: 100,
+                      y: 102,
                       gravity: 'south_west'
                     },
                   },
                   {
-                    width: 1400,
-                    crop: 'fit',
                     text: {
                       color: 'white',
                       fontFamily: 'Lato',
-                      fontSize: 74,
+                      fontSize: 37,
                       fontWeight: 'bold',
                       text: tagline
                     },
                     position: {
-                      x: 360,
-                      y: 200,
+                      x: 180,
+                      y: 100,
                       gravity: 'south_west'
                     },
                   },
@@ -262,67 +255,66 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
         overlays={[
           {
             publicId,
-            width: 2400,
-            height: 1254,
+            width: 1200,
+            height: 630,
             crop: 'fill',
             effects: [
               { opacity: 20 }
             ]
           },
           {
-            width: 2000,
+            width: 1000,
             crop: 'fit',
             text: {
               color: 'white',
-              fontFamily: 'Lato',
-              fontSize: 130,
-              fontWeight: 'black',
-              lineSpacing: 20,
+              fontFamily: 'Merriweather',
+              fontSize: 58,
+              fontWeight: 'bold',
+              lineSpacing: 10,
+              lineSpacing: 10,
               text: headline
             },
             position: {
-              x: 200,
-              y: 200,
+              x: 100,
+              y: 100,
               gravity: 'north_west'
             },
           },
           {
             publicId,
-            width: 2000,
-            height: 4,
+            width: 1000,
+            height: 2,
             effects: [{
               colorize: '100,co_white',
               opacity: 70
             }],
             position: {
-              x: 200,
-              y: 350,
+              x: 100,
+              y: 175,
               gravity: 'south_west'
             },
           },
           {
-            width: 120,
+            width: 60,
             crop: 'fit',
             publicId: logoPublicId,
             position: {
-              x: 200,
-              y: 205,
+              x: 100,
+              y: 102,
               gravity: 'south_west'
             },
           },
           {
-            width: 1400,
-            crop: 'fit',
             text: {
               color: 'white',
               fontFamily: 'Lato',
-              fontSize: 74,
+              fontSize: 37,
               fontWeight: 'bold',
               text: tagline
             },
             position: {
-              x: 360,
-              y: 200,
+              x: 180,
+              y: 100,
               gravity: 'south_west'
             },
           },
@@ -338,48 +330,44 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
 ## Full
 
 <HeaderImage>
-  <CldImage
-    width="2400"
-    height="1254"
-    crop="fill"
+  <ExamplesCldOgImage
     src={`${process.env.IMAGES_DIRECTORY}/mountain`}
     colorize="100,co_black"
-    sizes="100w"
     overlays={[
       {
         publicId: 'images/mountain',
-        width: 2400,
-        height: 1254,
+        width: 1200,
+        height: 630,
         crop: 'fill',
         effects: [{ opacity: 60 }]
       },
       {
-        width: 1400,
+        width: 700,
         crop: 'fit',
         text: {
           alignment: 'center',
           color: 'white',
           fontFamily: 'Source Sans Pro',
-          fontSize: 160,
+          fontSize: 80,
           fontWeight: 'bold',
           text: 'Next Cloudinary'
         },
         position: {
-          y: -100,
+          y: -50,
         },
       },
       {
-        width: 1400,
+        width: 700,
         crop: 'fit',
         text: {
           alignment: 'center',
           color: 'white',
           fontFamily: 'Source Sans Pro',
-          fontSize: 74,
+          fontSize: 37,
           text: 'Get the power of Cloudinary in a Next.js project with Next Cloudinary!'
         },
         position: {
-          y: 100,
+          y: 50,
         },
       },
     ]}
@@ -395,7 +383,7 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
     > Note: you can alternatively use this function to pass dynamic values using the
     [generateMetadata function](https://nextjs.org/docs/app/api-reference/functions/generate-metadata).
 
-    <CodeBlock>
+    <CodeBlock className="mt-6">
       ```jsx copy showLineNumbers
       import { Metadata } from 'next';
       import { getCldOgImageUrl } from 'next-cloudinary';
@@ -411,47 +399,47 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
               // Prefer a different size? Be sure to update the width and height of the
               // metadata as well as the image configuration of getCldOgImageUrl
               width: 1200,
-              height: 627,
+              height: 630,
               url: getCldOgImageUrl({
                 src: publicId,
                 effects: [{ colorize: '100,co_black' }],
                 overlays: [
                   {
                     publicId,
-                    width: 2400,
-                    height: 1254,
+                    width: 1200,
+                    height: 630,
                     crop: 'fill',
                     effects: [{
                       opacity: 60
                     }]
                   },
                   {
-                    width: 1400,
+                    width: 700,
                     crop: 'fit',
                     text: {
                       alignment: 'center',
                       color: 'white',
                       fontFamily: 'Source Sans Pro',
-                      fontSize: 160,
+                      fontSize: 80,
                       fontWeight: 'bold',
                       text: headline
                     },
                     position: {
-                      y: -100,
+                      y: -50,
                     },
                   },
                   {
-                    width: 1400,
+                    width: 700,
                     crop: 'fit',
                     text: {
                       alignment: 'center',
                       color: 'white',
                       fontFamily: 'Source Sans Pro',
-                      fontSize: 74,
+                      fontSize: 37,
                       text: body
                     },
                     position: {
-                      y: 100,
+                      y: 50,
                     },
                   },
                 ]
@@ -482,40 +470,40 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
         overlays={[
           {
             publicId,
-            width: 2400,
-            height: 1254,
+            width: 1200,
+            height: 630,
             crop: 'fill',
             effects: [{
               opacity: 60
             }]
           },
           {
-            width: 1400,
+            width: 700,
             crop: 'fit',
             text: {
               alignment: 'center',
               color: 'white',
               fontFamily: 'Source Sans Pro',
-              fontSize: 160,
+              fontSize: 80,
               fontWeight: 'bold',
               text: headline
             },
             position: {
-              y: -100,
+              y: -50,
             },
           },
           {
-            width: 1400,
+            width: 700,
             crop: 'fit',
             text: {
               alignment: 'center',
               color: 'white',
               fontFamily: 'Source Sans Pro',
-              fontSize: 74,
+              fontSize: 37,
               text: body
             },
             position: {
-              y: 100,
+              y: 50,
             },
           },
         ]}
@@ -530,13 +518,9 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
 ## One Third
 
 <HeaderImage>
-  <CldImage
-    width="2400"
-    height="1254"
-    crop="fill"
+  <ExamplesCldOgImage
     src={`${process.env.IMAGES_DIRECTORY}/mountain`}
     colorize="100,co_white"
-    sizes="100w"
     overlays={[
       {
         publicId: 'images/mountain',
@@ -547,39 +531,40 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
           {
             crop: 'fill',
             gravity: 'auto',
-            width: 800,
-            height: 1254
+            width: '0.33',
+            height: '1.0'
           }
-        ]
+        ],
+        flags: ['relative']
       },
       {
-        width: 1250,
+        width: 625,
         crop: 'fit',
         text: {
           color: 'black',
           fontFamily: 'Source Sans Pro',
-          fontSize: 160,
+          fontSize: 80,
           fontWeight: 'bold',
           text: 'Next Cloudinary'
         },
         position: {
-          x: 250,
-          y: -100,
+          x: 125,
+          y: -50,
           gravity: 'west',
         },
       },
       {
-        width: 1250,
+        width: 625,
         crop: 'fit',
         text: {
           color: 'black',
           fontFamily: 'Source Sans Pro',
-          fontSize: 74,
+          fontSize: 37,
           text: 'Get the power of Cloudinary in a Next.js project with Next Cloudinary!'
         },
         position: {
-          x: 250,
-          y: 100,
+          x: 125,
+          y: 50,
           gravity: 'west',
         },
       },
@@ -596,7 +581,7 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
     > Note: you can alternatively use this function to pass dynamic values using the
     [generateMetadata function](https://nextjs.org/docs/app/api-reference/functions/generate-metadata).
 
-    <CodeBlock>
+    <CodeBlock className="mt-6">
       ```jsx copy showLineNumbers
       import { Metadata } from 'next';
       import { getCldOgImageUrl } from 'next-cloudinary';
@@ -612,7 +597,7 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
               // Prefer a different size? Be sure to update the width and height of the
               // metadata as well as the image configuration of getCldOgImageUrl
               width: 1200,
-              height: 627,
+              height: 630,
               url: getCldOgImageUrl({
                 src: publicId,
                 effects: [{ colorize: '100,co_white' }],
@@ -626,39 +611,40 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
                       {
                         crop: 'fill',
                         gravity: 'auto',
-                        width: 800,
-                        height: 1254
+                        width: '0.33',
+                        height: '1.0'
                       }
-                    ]
+                    ],
+                    flags: ['relative']
                   },
                   {
-                    width: 1250,
+                    width: 625,
                     crop: 'fit',
                     text: {
                       color: 'black',
                       fontFamily: 'Source Sans Pro',
-                      fontSize: 160,
+                      fontSize: 80,
                       fontWeight: 'bold',
                       text: headline
                     },
                     position: {
-                      x: 250,
-                      y: -100,
+                      x: 125,
+                      y: -50,
                       gravity: 'west',
                     },
                   },
                   {
-                    width: 1250,
+                    width: 625,
                     crop: 'fit',
                     text: {
                       color: 'black',
                       fontFamily: 'Source Sans Pro',
-                      fontSize: 74,
+                      fontSize: 37,
                       text: body
                     },
                     position: {
-                      x: 250,
-                      y: 100,
+                      x: 125,
+                      y: 50,
                       gravity: 'west',
                     },
                   },
@@ -697,39 +683,40 @@ import { CldImage, CldOgImage } from '../../../next-cloudinary';
               {
                 crop: 'fill',
                 gravity: 'auto',
-                width: 800,
-                height: 1254
+                width: '0.33',
+                height: '1.0'
               }
-            ]
+            ],
+            flags: ['relative']
           },
           {
-            width: 1250,
+            width: 625,
             crop: 'fit',
             text: {
               color: 'black',
               fontFamily: 'Source Sans Pro',
-              fontSize: 160,
+              fontSize: 80,
               fontWeight: 'bold',
               text: headline
             },
             position: {
-              x: 250,
-              y: -100,
+              x: 125,
+              y: -50,
               gravity: 'west',
             },
           },
           {
-            width: 1250,
+            width: 625,
             crop: 'fit',
             text: {
               color: 'black',
               fontFamily: 'Source Sans Pro',
-              fontSize: 74,
+              fontSize: 37,
               text: body
             },
             position: {
-              x: 250,
-              y: 100,
+              x: 125,
+              y: 50,
               gravity: 'west',
             },
           },

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@cloudinary-util/types": "1.0.0",
-    "@cloudinary-util/url-loader": "5.0.0-beta.2",
+    "@cloudinary-util/url-loader": "5.0.0-beta.3",
     "@cloudinary-util/util": "^2.3.0"
   },
   "devDependencies": {

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@cloudinary-util/types": "1.0.0",
-    "@cloudinary-util/url-loader": "5.0.0-beta.1",
+    "@cloudinary-util/url-loader": "5.0.0-beta.2",
     "@cloudinary-util/util": "^2.3.0"
   },
   "devDependencies": {

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@cloudinary-util/types": "1.0.0",
-    "@cloudinary-util/url-loader": "4.2.0",
+    "@cloudinary-util/url-loader": "5.0.0-beta.1",
     "@cloudinary-util/util": "^2.3.0"
   },
   "devDependencies": {

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "cp ../README.md . && cp ../LICENSE . && pnpm build",
     "postpublish": "rm ./README.md && rm ./LICENSE",
     "test": "jest",
-    "test:app": "NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=\"test\" pnpm build && cd tests/nextjs-app && pnpm build"
+    "test:app": "NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=\"test\" pnpm build && cd tests/nextjs-app && npm install && npm build"
   },
   "dependencies": {
     "@cloudinary-util/types": "1.0.0",

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "cp ../README.md . && cp ../LICENSE . && pnpm build",
     "postpublish": "rm ./README.md && rm ./LICENSE",
     "test": "jest",
-    "test:app": "NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=\"test\" pnpm build && cd tests/nextjs-app && npm install && npm build"
+    "test:app": "NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=\"test\" pnpm build && cd tests/nextjs-app && npm install && npm run build"
   },
   "dependencies": {
     "@cloudinary-util/types": "1.0.0",

--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -138,8 +138,18 @@ const CldImage = forwardRef<HTMLImageElement, CldImageProps>(function CldImage(p
 
   const handleOnError = useCallback(onError, [pollForProcessingImage, defaultImgKey]);
 
+  // Copypasta from https://github.com/prismicio/prismic-next/pull/79/files
+  // Thanks Angelo!
+  // TODO: Remove once https://github.com/vercel/next.js/issues/52216 is resolved.
+
+  let ResolvedImage = Image;
+
+  if ("default" in ResolvedImage) {
+    ResolvedImage = (ResolvedImage as unknown as { default: typeof Image }).default;
+  }
+
   return (
-    <Image
+    <ResolvedImage
       key={imgKey}
       {...imageProps}
       loader={(loaderOptions) => cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldConfig: props.config })}

--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -138,18 +138,8 @@ const CldImage = forwardRef<HTMLImageElement, CldImageProps>(function CldImage(p
 
   const handleOnError = useCallback(onError, [pollForProcessingImage, defaultImgKey]);
 
-  // Copypasta from https://github.com/prismicio/prismic-next/pull/79/files
-  // Thanks Angelo!
-  // TODO: Remove once https://github.com/vercel/next.js/issues/52216 is resolved.
-
-  let ResolvedImage = Image;
-
-  if ("default" in ResolvedImage) {
-    ResolvedImage = (ResolvedImage as unknown as { default: typeof Image }).default;
-  }
-
   return (
-    <ResolvedImage
+    <Image
       key={imgKey}
       {...imageProps}
       loader={(loaderOptions) => cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldConfig: props.config })}

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Head from 'next/head';
-import type { ImageOptions } from '@cloudinary-util/url-loader';
 
 import { CldImageProps } from '../CldImage/CldImage';
 import { getCldImageUrl } from '../../helpers/getCldImageUrl';
-import { OG_IMAGE_WIDTH, OG_IMAGE_WIDTH_RESIZE, OG_IMAGE_HEIGHT } from '../../constants/sizes';
+import { getCldOgImageUrl } from '../../helpers/getCldOgImageUrl';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../constants/sizes';
 
 const TWITTER_CARD = 'summary_large_image';
 
@@ -17,38 +17,34 @@ export type CldOgImageProps = CldImageProps & {
 const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: CldOgImageProps) => {
   const { alt } = props;
 
-  const options: ImageOptions = {
-    ...props,
-    crop: props.crop || 'fill',
-    gravity: props.gravity || 'center',
-    height: props.height || OG_IMAGE_HEIGHT,
-    src: props.src,
-    width: props.width || OG_IMAGE_WIDTH,
-    widthResize: props.width || OG_IMAGE_WIDTH_RESIZE
-  }
+  // We need to separately handle the width and the height to allow our user to pass in
+  // a custom value, but also we need to know this at the component level so that we can
+  // use it when rendering the meta tags
 
-  let width = typeof options.width === 'string' ? parseInt(options.width) : options.width;
-  let height = typeof options.height === 'string' ? parseInt(options.height) : options.height;
+  let {
+    width = OG_IMAGE_WIDTH,
+    height = OG_IMAGE_HEIGHT
+  } = props;
 
-  // Resize the height based on the widthResize property
+  // Normalize the width and height
 
-  if ( typeof height === 'number' && typeof width === 'number' ) {
-    height = ( OG_IMAGE_WIDTH_RESIZE / width ) * height;
-  }
-
-  width = OG_IMAGE_WIDTH_RESIZE;
+  width = typeof width === 'string' ? parseInt(width) : width;
+  height = typeof height === 'string' ? parseInt(height) : height;
 
   // Render the final URLs. We use two different format versions to deliver
   // webp for Twitter as it supports it (and we can control with tags) where
   // other platforms may not support webp, so we deliver jpg
 
-  const ogImageUrl = getCldImageUrl({
-    ...options,
-    format: props.format || 'jpg',
+  const ogImageUrl = getCldOgImageUrl({
+    ...props,
+    width,
+    height
   });
 
   const twitterImageUrl = getCldImageUrl({
-    ...options,
+    ...props,
+    width,
+    height,
     format: props.format || 'webp',
   });
 

--- a/next-cloudinary/src/constants/sizes.ts
+++ b/next-cloudinary/src/constants/sizes.ts
@@ -1,3 +1,2 @@
-export const OG_IMAGE_WIDTH = 2400;
-export const OG_IMAGE_WIDTH_RESIZE = 1200;
-export const OG_IMAGE_HEIGHT = 1254;
+export const OG_IMAGE_WIDTH = 1200;
+export const OG_IMAGE_HEIGHT = 627;

--- a/next-cloudinary/src/helpers/getCldOgImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldOgImageUrl.ts
@@ -1,4 +1,4 @@
-import { OG_IMAGE_WIDTH, OG_IMAGE_WIDTH_RESIZE, OG_IMAGE_HEIGHT } from '../constants/sizes';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../constants/sizes';
 
 import { getCldImageUrl } from './getCldImageUrl';
 import type { GetCldImageUrlOptions } from './getCldImageUrl';
@@ -12,11 +12,12 @@ export type GetCldOgImageUrlOptions = GetCldImageUrlOptions;
 export function getCldOgImageUrl(options: GetCldOgImageUrlOptions) {
   return getCldImageUrl({
     ...options,
-    crop: options.crop || 'fill',
     format: options.format || 'jpg',
-    gravity: options.gravity || 'center',
-    height: options.height || OG_IMAGE_HEIGHT,
     width: options.width || OG_IMAGE_WIDTH,
-    widthResize: options.width || OG_IMAGE_WIDTH_RESIZE
+    height: options.height || OG_IMAGE_HEIGHT,
+    baseCrop: options.baseCrop || 'fill',
+    baseGravity: options.baseGravity || 'center',
+    baseHeight: options.baseHeight || OG_IMAGE_HEIGHT,
+    baseWidth: options.baseWidth || OG_IMAGE_WIDTH
   });
 }

--- a/next-cloudinary/src/helpers/getCldOgImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldOgImageUrl.ts
@@ -18,6 +18,7 @@ export function getCldOgImageUrl(options: GetCldOgImageUrlOptions) {
     crop: options.crop || {
       crop: 'fill',
       gravity: 'center',
+      source: true
     }
   });
 }

--- a/next-cloudinary/src/helpers/getCldOgImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldOgImageUrl.ts
@@ -16,7 +16,7 @@ export function getCldOgImageUrl(options: GetCldOgImageUrlOptions) {
     width: options.width || OG_IMAGE_WIDTH,
     height: options.height || OG_IMAGE_HEIGHT,
     crop: options.crop || {
-      crop: 'fill',
+      type: 'fill',
       gravity: 'center',
       source: true
     }

--- a/next-cloudinary/src/helpers/getCldOgImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldOgImageUrl.ts
@@ -15,9 +15,9 @@ export function getCldOgImageUrl(options: GetCldOgImageUrlOptions) {
     format: options.format || 'jpg',
     width: options.width || OG_IMAGE_WIDTH,
     height: options.height || OG_IMAGE_HEIGHT,
-    baseCrop: options.baseCrop || 'fill',
-    baseGravity: options.baseGravity || 'center',
-    baseHeight: options.baseHeight || OG_IMAGE_HEIGHT,
-    baseWidth: options.baseWidth || OG_IMAGE_WIDTH
+    crop: options.crop || {
+      crop: 'fill',
+      gravity: 'center',
+    }
   });
 }

--- a/next-cloudinary/src/lib/cloudinary.ts
+++ b/next-cloudinary/src/lib/cloudinary.ts
@@ -19,7 +19,10 @@ export async function pollForProcessingImage(options: PollForProcessingImageOpti
       });
     });
   } catch(e: any) {
+    // Timeout for 200ms before trying to fetch again to avoid overwhelming requests
+
     if ( e.status === 423 ) {
+      await new Promise((resolve) => setTimeout(() => resolve(undefined), 200));
       return await pollForProcessingImage(options);
     }
     return false;

--- a/next-cloudinary/src/loaders/cloudinary-loader.ts
+++ b/next-cloudinary/src/loaders/cloudinary-loader.ts
@@ -50,6 +50,7 @@ export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldCon
     // The Fill option does not allow someone to pass in a width or a height
     // If this is the case, we still need to define a width for sizing optimization but also
     // for responsive sizing to take effect, so we can utilize the loader width for the base width
+    options.width = loaderOptions?.width;
   }
 
   // @ts-ignore

--- a/next-cloudinary/src/loaders/cloudinary-loader.ts
+++ b/next-cloudinary/src/loaders/cloudinary-loader.ts
@@ -23,18 +23,13 @@ export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldCon
     ...cldOptions
   }
 
-  console.log('options', options)
-  console.log('loaderOptions', loaderOptions)
   options.width = typeof options.width === 'string' ? parseInt(options.width) : options.width;
   options.height = typeof options.height === 'string' ? parseInt(options.height) : options.height;
-
   
   // // The loader options are used to create dynamic sizing when working with responsive images
   // // so these should override the default options collected from the props alone if
   // // the results are different. While we don't always use the height in the loader logic,
   // // we always pass it here, as the usage is determined later based on cropping.js
-
-  // let widthResize;
 
   if ( typeof loaderOptions?.width === 'number' && typeof options.width === 'number' && loaderOptions.width !== options.width ) {
     const multiplier = loaderOptions.width / options.width;

--- a/next-cloudinary/src/loaders/cloudinary-loader.ts
+++ b/next-cloudinary/src/loaders/cloudinary-loader.ts
@@ -3,7 +3,6 @@ import { ImageProps } from 'next/image';
 import { getCldImageUrl } from '../helpers/getCldImageUrl';
 
 export interface CloudinaryLoaderCldOptions {
-  widthResize?: string | number;
 }
 
 export interface CloudinaryLoaderLoaderOptions {
@@ -24,35 +23,38 @@ export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldCon
     ...cldOptions
   }
 
+  console.log('options', options)
+  console.log('loaderOptions', loaderOptions)
   options.width = typeof options.width === 'string' ? parseInt(options.width) : options.width;
   options.height = typeof options.height === 'string' ? parseInt(options.height) : options.height;
 
-  // The loader options are used to create dynamic sizing when working with responsive images
-  // so these should override the default options collected from the props alone if
-  // the results are different. While we don't always use the height in the loader logic,
-  // we always pass it here, as the usage is determined later based on cropping.js
+  
+  // // The loader options are used to create dynamic sizing when working with responsive images
+  // // so these should override the default options collected from the props alone if
+  // // the results are different. While we don't always use the height in the loader logic,
+  // // we always pass it here, as the usage is determined later based on cropping.js
 
-  let widthResize;
+  // let widthResize;
 
   if ( typeof loaderOptions?.width === 'number' && typeof options.width === 'number' && loaderOptions.width !== options.width ) {
-    widthResize = loaderOptions.width;
+    const multiplier = loaderOptions.width / options.width;
+    
+    options.width = loaderOptions.width;
+
+    // The height may change based off of the value passed through via the loader options
+    // In an example where the user sizes is 800x600, but the loader is passing in 400
+    // due to responsive sizing, we want to ensure we're using a height that will
+    // resolve to the same aspect ratio
+    
+    if ( typeof options.height === 'number' ) {
+      options.height = Math.floor(options.height * multiplier);
+    }
   } else if ( typeof loaderOptions?.width === 'number' && typeof options?.width !== 'number' ) {
     // If we don't have a width on the options object, this may mean that the component is using
     // the fill option: https://nextjs.org/docs/pages/api-reference/components/image#fill
     // The Fill option does not allow someone to pass in a width or a height
     // If this is the case, we still need to define a width for sizing optimization but also
     // for responsive sizing to take effect, so we can utilize the loader width for the base width
-
-    widthResize = loaderOptions.width;
-    options.width = widthResize;
-  }
-
-  // If we have a resize width that's smaller than the user-defined width, we want to give the
-  // ability to perform a final resize on the image without impacting any of the effects like text
-  // overlays that may depend on the size to work properly
-
-  if ( options.width && widthResize && widthResize < options.width ) {
-    options.widthResize = loaderOptions.width;
   }
 
   // @ts-ignore

--- a/next-cloudinary/tests/helpers/getCldImageUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldImageUrl.spec.js
@@ -1,5 +1,4 @@
 import { getCldImageUrl } from '../../src/helpers/getCldImageUrl';
-import { getCldVideoUrl } from '../../src/helpers/getCldVideoUrl';
 
 describe('Cloudinary', () => {
   const OLD_ENV = process.env;
@@ -26,22 +25,6 @@ describe('Cloudinary', () => {
       });
 
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
-    });
-  });
-
-  describe('getCldVideoUrl', () => {
-    it('should pass', () => {
-      const cloudName = 'customtestcloud';
-
-      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
-
-      const url = getCldVideoUrl({
-        src: 'turtle',
-        width: 100,
-        height: 100
-      });
-
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/video/upload/c_limit,w_100/f_auto/q_auto/turtle`);
     });
   });
 })

--- a/next-cloudinary/tests/helpers/getCldOgImageUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldOgImageUrl.spec.js
@@ -1,5 +1,5 @@
 import { getCldOgImageUrl } from '../../src/helpers/getCldOgImageUrl';
-import { OG_IMAGE_WIDTH_RESIZE, OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../src/constants/sizes';
+import { OG_IMAGE_WIDTH, OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../src/constants/sizes';
 
 describe('Cloudinary', () => {
   const OLD_ENV = process.env;
@@ -25,7 +25,7 @@ describe('Cloudinary', () => {
         src
       });
 
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_fill,w_${OG_IMAGE_WIDTH},h_${OG_IMAGE_HEIGHT},g_center/c_limit,w_${OG_IMAGE_WIDTH_RESIZE}/f_jpg/q_auto/${src}`);
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_fill,w_${OG_IMAGE_WIDTH},h_${OG_IMAGE_HEIGHT},g_center/c_limit,w_${OG_IMAGE_WIDTH}/f_jpg/q_auto/${src}`);
     });
 
     it('should allow customization of width and height', () => {

--- a/next-cloudinary/tests/helpers/getCldOgImageUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldOgImageUrl.spec.js
@@ -1,0 +1,49 @@
+import { getCldOgImageUrl } from '../../src/helpers/getCldOgImageUrl';
+import { OG_IMAGE_WIDTH_RESIZE, OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../src/constants/sizes';
+
+describe('Cloudinary', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  describe('getCldOgImageUrl', () => {
+    it('should pass use defaults to create a URL', () => {
+      const cloudName = 'customtestcloud';
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+
+      const src = 'turtle';
+
+      const url = getCldOgImageUrl({
+        src
+      });
+
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_fill,w_${OG_IMAGE_WIDTH},h_${OG_IMAGE_HEIGHT},g_center/c_limit,w_${OG_IMAGE_WIDTH_RESIZE}/f_jpg/q_auto/${src}`);
+    });
+
+    it('should allow customization of width and height', () => {
+      const cloudName = 'customtestcloud';
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+
+      const src = 'turtle';
+      const width = 800;
+      const height = 600;
+
+      const url = getCldOgImageUrl({
+        src,
+        width,
+        height
+      });
+
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_fill,w_${width},h_${height},g_center/c_limit,w_${width}/f_jpg/q_auto/${src}`);
+    });
+  });
+})

--- a/next-cloudinary/tests/helpers/getCldOgImageUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldOgImageUrl.spec.js
@@ -1,5 +1,5 @@
 import { getCldOgImageUrl } from '../../src/helpers/getCldOgImageUrl';
-import { OG_IMAGE_WIDTH, OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../src/constants/sizes';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../src/constants/sizes';
 
 describe('Cloudinary', () => {
   const OLD_ENV = process.env;

--- a/next-cloudinary/tests/helpers/getCldVideoUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldVideoUrl.spec.js
@@ -1,0 +1,30 @@
+import { getCldVideoUrl } from '../../src/helpers/getCldVideoUrl';
+
+describe('Cloudinary', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+  
+  describe('getCldVideoUrl', () => {
+    it('should pass', () => {
+      const cloudName = 'customtestcloud';
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+
+      const url = getCldVideoUrl({
+        src: 'turtle',
+        width: 100,
+        height: 100
+      });
+
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/video/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+    });
+  });
+})

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -46,11 +46,11 @@ describe('Cloudinary Loader', () => {
         removeBackground: true,
         crop: [
           {
-            crop: 'thumb',
+            type: 'thumb',
             source: true
           },
           {
-            crop: 'scale'
+            type: 'scale'
           }
         ],
         gravity: 'faces',
@@ -163,7 +163,7 @@ describe('Cloudinary Loader', () => {
         crop: {
           width: 1234,
           height: 4321,
-          crop: 'fill',
+          type: 'fill',
           source: true
         },
         overlays: [{
@@ -179,15 +179,15 @@ describe('Cloudinary Loader', () => {
 
       const loaderOptions1 = { width: 2048 };
       const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.crop},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions2 = { width: 3840 };
       const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.crop},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions3 = { width: 640 };
       const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.crop},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
 
     it('should add any resizing when fill is set to true without a width or height', async () => {

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -31,20 +31,28 @@ describe('Cloudinary Loader', () => {
 
     it('should return a Cloudinary URL with advanced options', () => {
       const imageProps = {
-        width: '987',
-        height: '1481',
+        width: 987,
+        height: 1481,
         src: 'images/woman-headphones',
         sizes: '100vw',
       }
 
       const loaderOptions = {
         src: 'images/woman-headphones',
-        width: 987
+        width: 987,
       }
 
       const cldOptions = {
         removeBackground: true,
-        crop: 'thumb',
+        crop: [
+          {
+            crop: 'thumb',
+            source: true
+          },
+          {
+            crop: 'scale'
+          }
+        ],
         gravity: 'faces',
         tint: '40:253f8c',
         underlays: [
@@ -59,7 +67,9 @@ describe('Cloudinary Loader', () => {
 
       const result = cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldConfig });
 
-      expect(result).toContain('https://res.cloudinary.com/test-cloud/image/upload/e_background_removal/c_thumb,w_987,h_1481,g_faces/e_tint:40:253f8c/u_images:city-skyline,w_987,h_987,c_fill/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/woman-headphones')
+      // Note: g_auto is expected in the initial transformation as we can't infer usage of
+      // gravity for which transformation to apply it to via URL Loader
+      expect(result).toContain(`https://res.cloudinary.com/test-cloud/image/upload/e_background_removal/c_thumb,w_987,h_1481,g_auto/e_tint:40:253f8c/u_images:city-skyline,w_987,h_987,c_fill/fl_layer_apply,fl_no_overflow/c_scale,w_${imageProps.width},h_${imageProps.height}/f_auto/q_auto/v1/images/woman-headphones`)
     });
 
     it('should return a Cloudinary URL with fetch features', async () => {
@@ -94,77 +104,23 @@ describe('Cloudinary Loader', () => {
       // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
       const loaderOptions1 = { width: 2048 };
       const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions2 = { width: 3840 };
       const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions3 = { width: 640 };
       const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
-    });
-
-    it('should return responsive images without upscaling for smaller images', async () => {
-      const imageProps = {
-        height: '600',
-        sizes: '100vw',
-        src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg',
-        width: '960',
-        deliveryType: 'fetch'
-      }
-
-      const cldOptions = {};
-
-      // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
-
-      const loaderOptions1 = { width: 2048 };
-      const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
-
-      const loaderOptions2 = { width: 3840 };
-      const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
-
-      const loaderOptions3 = { width: 640 };
-      const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
-    });
-
-    it('should return a responsive images with height when crop is not limit without upscaling', async () => {
-      const imageProps = {
-        height: '600',
-        sizes: '100vw',
-        src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg',
-        width: '960',
-        deliveryType: 'fetch',
-      }
-
-      const cldOptions = {
-        crop: 'fill'
-      };
-
-      // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
-
-      const loaderOptions1 = { width: 2048 };
-      const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
-
-      const loaderOptions2 = { width: 3840 };
-      const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
-
-      const loaderOptions3 = { width: 640 };
-      const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
 
     it('should add any resizing after any effects are added', async () => {
       const imageProps = {
-        height: '600',
+        height: 600,
         sizes: '100vw',
         src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg',
-        width: '960',
+        width: 960,
         deliveryType: 'fetch',
       }
 
@@ -183,15 +139,55 @@ describe('Cloudinary Loader', () => {
 
       const loaderOptions1 = { width: 2048 };
       const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions1.width},h_${(loaderOptions1.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions2 = { width: 3840 };
       const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions2.width},h_${(loaderOptions2.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions3 = { width: 640 };
       const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions3.width},h_${(loaderOptions3.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+    });
+
+    it('should add two-stage resizing and cropping', async () => {
+      const imageProps = {
+        height: 600,
+        sizes: '100vw',
+        src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg',
+        width: 960,
+        deliveryType: 'fetch',
+      }
+
+      const cldOptions = {
+        crop: {
+          width: 1234,
+          height: 4321,
+          crop: 'fill',
+          source: true
+        },
+        overlays: [{
+          url: 'https://user-images.githubusercontent.com/1045274/199872380-ced2b84d-fce4-4fc9-9e76-48cb4a7fb35f.png'
+        }]
+      };
+
+      const urlBufer = Buffer.from(cldOptions.overlays[0].url);
+      const urlBase64 = urlBufer.toString('base64');
+      const urlParam = encodeURIComponent(urlBase64);
+
+      // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
+
+      const loaderOptions1 = { width: 2048 };
+      const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
+      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.crop},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+
+      const loaderOptions2 = { width: 3840 };
+      const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
+      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.crop},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+
+      const loaderOptions3 = { width: 640 };
+      const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
+      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.crop},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
 
     it('should add any resizing when fill is set to true without a width or height', async () => {

--- a/next-cloudinary/tests/nextjs-app/package-lock.json
+++ b/next-cloudinary/tests/nextjs-app/package-lock.json
@@ -1,0 +1,3866 @@
+{
+  "name": "nextjs-app",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nextjs-app",
+      "version": "0.1.0",
+      "dependencies": {
+        "@types/node": "^20.11.19",
+        "@types/react": "^18.2.57",
+        "@types/react-dom": "^18.2.19",
+        "eslint": "^8.56.0",
+        "eslint-config-next": "^14.1.0",
+        "next": "^14.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw=="
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.0.tgz",
+      "integrity": "sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw=="
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.0.tgz",
+      "integrity": "sha512-x4FavbNEeXx/baD/zC/SdrvkjSby8nBn8KcCREqk6UuwvwoAPZmaV8TFCAuo/cpovBRTIY67mHhe86MQQm/68Q==",
+      "dependencies": {
+        "glob": "10.3.10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
+      "integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
+      "integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz",
+      "integrity": "sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz",
+      "integrity": "sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
+      "integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
+      "integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
+      "integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
+      "integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
+      "integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz",
+      "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA=="
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
+      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.57",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
+      "integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.19",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
+      "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/acorn": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.filter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
+      "integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.4.tgz",
+      "integrity": "sha512-hzvSHUshSpCflDR1QMUBLHGHP1VIEBegT4pix9H/Z92Xw3ySoy6c2qh7lJWTJnRJ8JCZ9bJNCgTyYaJGcJu6xQ==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.3.tgz",
+      "integrity": "sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.1.0",
+        "es-shim-unscopables": "^1.0.2"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
+        "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="
+    },
+    "node_modules/asynciterator.prototype": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
+      "integrity": "sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
+      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001589",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
+      "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.4.tgz",
+      "integrity": "sha512-vZYJlk2u6qHYxBOTjAeg7qUxHdNfih64Uu2J8QqWgXZ2cri0ZpJAkzDUK/q593+mvKwlxyaxr6F1Q+3LKoQRgg==",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.6",
+        "call-bind": "^1.0.7",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.1",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.13",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.13.1",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.0",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.8",
+        "string.prototype.trimend": "^1.0.7",
+        "string.prototype.trimstart": "^1.0.7",
+        "typed-array-buffer": "^1.0.1",
+        "typed-array-byte-length": "^1.0.0",
+        "typed-array-byte-offset": "^1.0.0",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.17.tgz",
+      "integrity": "sha512-lh7BsUqelv4KUbR5a/ZTaGGIMLCjPGPqJ6q+Oq24YP0RdyptX1uzm4vvaqzk7Zx3bpl/76YLTTDj9L7uYQ92oQ==",
+      "dependencies": {
+        "asynciterator.prototype": "^1.0.0",
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.4",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.2",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "globalthis": "^1.0.3",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.7",
+        "iterator.prototype": "^1.1.2",
+        "safe-array-concat": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.1.0.tgz",
+      "integrity": "sha512-SBX2ed7DoRFXC6CQSLc/SbLY9Ut6HxNB2wPTcoIWjUMd7aF7O/SIE7111L8FdZ9TXsNV4pulUDnfthpyPtbFUg==",
+      "dependencies": {
+        "@next/eslint-plugin-next": "14.1.0",
+        "@rushstack/eslint-patch": "^1.3.3",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+      "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
+      "dependencies": {
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.8.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
+      "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "aria-query": "^5.3.0",
+        "array-includes": "^3.1.7",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "=4.7.0",
+        "axobject-query": "^3.2.1",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "es-iterator-helpers": "^1.0.15",
+        "hasown": "^2.0.0",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.7",
+        "object.fromentries": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.33.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
+      "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.0.12",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.4",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "node_modules/fastq": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+      "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dependencies": {
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dependencies": {
+        "which-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
+      "integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "get-intrinsic": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "reflect.getprototypeof": "^1.0.4",
+        "set-function-name": "^2.0.1"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
+      "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w=="
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "node_modules/next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
+      "integrity": "sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==",
+      "dependencies": {
+        "@next/env": "14.1.0",
+        "@swc/helpers": "0.5.2",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.1.0",
+        "@next/swc-darwin-x64": "14.1.0",
+        "@next/swc-linux-arm64-gnu": "14.1.0",
+        "@next/swc-linux-arm64-musl": "14.1.0",
+        "@next/swc-linux-x64-gnu": "14.1.0",
+        "@next/swc-linux-x64-musl": "14.1.0",
+        "@next/swc-win32-arm64-msvc": "14.1.0",
+        "@next/swc-win32-ia32-msvc": "14.1.0",
+        "@next/swc-win32-x64-msvc": "14.1.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.7.tgz",
+      "integrity": "sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
+      "integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.2.tgz",
+      "integrity": "sha512-bzBq58S+x+uo0VjurFT0UktpKHOZmv4/xePiOA1nbB9pMqpGK7rUPNgf+1YC+7mE+0HzhTMqNUuCqvKhj6FnBw==",
+      "dependencies": {
+        "array.prototype.filter": "^1.0.3",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.0.0"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.3.tgz",
+      "integrity": "sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==",
+      "dependencies": {
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
+      "integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.5.tgz",
+      "integrity": "sha512-62wgfC8dJWrmxv44CA36pLDnP6KKl3Vhxb7PL+8+qrrFMMoJij4vgiMP8zV4O8+CBMXY1mHxI5fITGHXFHVmQQ==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.0.0",
+        "get-intrinsic": "^1.2.3",
+        "globalthis": "^1.0.3",
+        "which-builtin-type": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+      "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "get-intrinsic": "^1.2.2",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
+      "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "dependencies": {
+        "define-data-property": "^1.1.2",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.3",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
+      "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
+      "integrity": "sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "regexp.prototype.flags": "^1.5.0",
+        "set-function-name": "^2.0.0",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.5.tgz",
+      "integrity": "sha512-yMi0PlwuznKHxKmcpoOdeLwxBoVPkqZxd7q2FgMkmD3bNwvF5VW0+UlUQ1k1vmktTu4Yu13Q0RIxEP8+B+wloA==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
+      "integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
+      "dependencies": {
+        "function.prototype.name": "^1.1.5",
+        "has-tostringtag": "^1.0.0",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.0.5",
+        "is-finalizationregistry": "^1.0.2",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.1.4",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
+      "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.6",
+        "call-bind": "^1.0.5",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/next-cloudinary/tests/nextjs-app/package.json
+++ b/next-cloudinary/tests/nextjs-app/package.json
@@ -9,12 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@types/node": "^20.11.4",
-    "@types/react": "^18.2.48",
-    "@types/react-dom": "^18.2.18",
+    "@types/node": "^20.11.19",
+    "@types/react": "^18.2.57",
+    "@types/react-dom": "^18.2.19",
     "eslint": "^8.56.0",
-    "eslint-config-next": "^14.0.4",
-    "next": "^14.0.4",
+    "eslint-config-next": "^14.1.0",
+    "next": "^14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@cloudinary-util/url-loader':
-        specifier: 5.0.0-beta.2
-        version: 5.0.0-beta.2
+        specifier: 5.0.0-beta.3
+        version: 5.0.0-beta.3
       '@cloudinary-util/util':
         specifier: ^2.3.0
         version: 2.4.0
@@ -1358,8 +1358,8 @@ packages:
       zod: 3.22.4
     dev: false
 
-  /@cloudinary-util/url-loader@5.0.0-beta.2:
-    resolution: {integrity: sha512-ucVlWgSwy5jGjMGxz/m8fGFoAFSxaFJkoc0lwbOS2vA+lwSzeDQbiRHnA4V3dG9zuiizBVEs8RN83AhyYZlNAA==}
+  /@cloudinary-util/url-loader@5.0.0-beta.3:
+    resolution: {integrity: sha512-5Hsga1/on+3RMUkusXpCo1sazXbU55+2xPO7DOShbuc1CJZRUyebKVNifokvE5TRAVWmsQBqsW/7d0o7aX2SLw==}
     dependencies:
       '@cloudinary-util/util': 3.0.0
       '@cloudinary/url-gen': 1.15.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,26 +30,26 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@vercel/analytics':
-        specifier: ^1.0.1
-        version: 1.1.2
+        specifier: ^1.2.2
+        version: 1.2.2(next@14.1.0)(react@18.2.0)
       cloudinary:
-        specifier: ^1.37.3
-        version: 1.41.3
+        specifier: ^2.0.1
+        version: 2.0.1
       clsx:
         specifier: ^2.1.0
         version: 2.1.0
       next:
-        specifier: ^14.0.0
-        version: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.70.0)
+        specifier: ^14.1.0
+        version: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.71.1)
       nextjs-google-analytics:
         specifier: ^2.3.3
         version: 2.3.3(next@14.1.0)(react@18.2.0)
       nextra:
-        specifier: ^2.13.2
-        version: 2.13.2(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^2.13.3
+        version: 2.13.3(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
-        specifier: ^2.13.2
-        version: 2.13.2(next@14.1.0)(nextra@2.13.2)(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^2.13.3
+        version: 2.13.3(next@14.1.0)(nextra@2.13.3)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -57,23 +57,23 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       react-icons:
-        specifier: ^4.11.0
-        version: 4.12.0(react@18.2.0)
+        specifier: ^5.0.1
+        version: 5.0.1(react@18.2.0)
       sass:
-        specifier: ^1.63.6
-        version: 1.70.0
+        specifier: ^1.71.1
+        version: 1.71.1
       tailwind-merge:
         specifier: ^2.2.1
         version: 2.2.1
     devDependencies:
       autoprefixer:
-        specifier: ^10.4.16
-        version: 10.4.17(postcss@8.4.33)
+        specifier: ^10.4.17
+        version: 10.4.17(postcss@8.4.35)
       postcss:
-        specifier: ^8.4.31
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
       tailwindcss:
-        specifier: ^3.3.5
+        specifier: ^3.4.1
         version: 3.4.1
 
   next-cloudinary:
@@ -2797,9 +2797,19 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: false
 
-  /@vercel/analytics@1.1.2:
-    resolution: {integrity: sha512-CodhkLCQ/EHzjX8k+Qg+OzTBY0UadykrcfolfSOJVZZY/ZJM5nbhztm9KdbYvMfqKlasAr1+OYy0ThZnDA/MYA==}
+  /@vercel/analytics@1.2.2(next@14.1.0)(react@18.2.0):
+    resolution: {integrity: sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==}
+    peerDependencies:
+      next: '>= 13'
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      next:
+        optional: true
+      react:
+        optional: true
     dependencies:
+      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.71.1)
+      react: 18.2.0
       server-only: 0.0.1
     dev: false
 
@@ -2983,7 +2993,7 @@ packages:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: true
 
-  /autoprefixer@10.4.17(postcss@8.4.33):
+  /autoprefixer@10.4.17(postcss@8.4.35):
     resolution: {integrity: sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
@@ -2995,7 +3005,7 @@ packages:
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -3346,20 +3356,10 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
-  /cloudinary-core@2.13.0(lodash@4.17.21):
-    resolution: {integrity: sha512-Nt0Q5I2FtenmJghtC4YZ3MZZbGg1wLm84SsxcuVwZ83OyJqG9CNIGp86CiI6iDv3QobaqBUpOT7vg+HqY5HxEA==}
-    peerDependencies:
-      lodash: '>=4.0'
+  /cloudinary@2.0.1:
+    resolution: {integrity: sha512-+j5GswtCwjAmLhjs/K26id4Zvh53zL/YWzgyenxgbdXdXmdFM8d5H1FV1sJCkpS77AqylJKBzyztySdILM+F+A==}
+    engines: {node: '>=9'}
     dependencies:
-      lodash: 4.17.21
-    dev: false
-
-  /cloudinary@1.41.3:
-    resolution: {integrity: sha512-4o84y+E7dbif3lMns+p3UW6w6hLHEifbX/7zBJvaih1E9QNMZITENQ14GPYJC4JmhygYXsuuBb9bRA3xWEoOfg==}
-    engines: {node: '>=0.6'}
-    dependencies:
-      cloudinary-core: 2.13.0(lodash@4.17.21)
-      core-js: 3.35.0
       lodash: 4.17.21
       q: 1.5.1
     dev: false
@@ -3489,11 +3489,6 @@ packages:
     dependencies:
       browserslist: 4.22.2
     dev: true
-
-  /core-js@3.35.0:
-    resolution: {integrity: sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==}
-    requiresBuild: true
-    dev: false
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -6680,7 +6675,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.70.0)
+      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.71.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -6692,7 +6687,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.70.0)
+      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.71.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -6736,7 +6731,7 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next@14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.70.0):
+  /next@14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.71.1):
     resolution: {integrity: sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -6759,7 +6754,7 @@ packages:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      sass: 1.70.0
+      sass: 1.71.1
       styled-jsx: 5.1.1(@babel/core@7.23.7)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.0
@@ -6782,17 +6777,17 @@ packages:
       next: '>=11.0.0'
       react: '>=17.0.0'
     dependencies:
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.70.0)
+      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.71.1)
       react: 18.2.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: false
 
-  /nextra-theme-docs@2.13.2(next@14.1.0)(nextra@2.13.2)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-yE4umXaImp1/kf/sFciPj2+EFrNSwd9Db26hi98sIIiujzGf3+9eUgAz45vF9CwBw50FSXxm1QGRcY+slQ4xQQ==}
+  /nextra-theme-docs@2.13.3(next@14.1.0)(nextra@2.13.3)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-B6xrnR86Gg4GzV56AomSwtmvSyAvnJz1xKOGGav1XKxkwvC8QeI17jdt/CqiKyIObJ+5bLqSFiKhaAZ5DYQP3g==}
     peerDependencies:
       next: '>=9.5.3'
-      nextra: 2.13.2
+      nextra: 2.13.3
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
@@ -6805,18 +6800,18 @@ packages:
       git-url-parse: 13.1.1
       intersection-observer: 0.12.2
       match-sorter: 6.3.3
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.70.0)
+      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.71.1)
       next-seo: 6.4.0(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.13.2(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.13.3(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.1.0
       zod: 3.22.4
     dev: false
 
-  /nextra@2.13.2(next@14.1.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-pIgOSXNUqTz1laxV4ChFZOU7lzJAoDHHaBPj8L09PuxrLKqU1BU/iZtXAG6bQeKCx8EPdBsoXxEuENnL9QGnGA==}
+  /nextra@2.13.3(next@14.1.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-OBVuyQKh+oqrbVt0AosgNYnuReWuNrtJVEN7q18b/oEg2wEpuiq3UJfmIvGgOdNYc3zv3OYrzbcq7IhwtdHHEw==}
     engines: {node: '>=16'}
     peerDependencies:
       next: '>=9.5.3'
@@ -6835,7 +6830,7 @@ packages:
       gray-matter: 4.0.3
       katex: 0.16.9
       lodash.get: 4.4.2
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.70.0)
+      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.71.1)
       next-mdx-remote: 4.4.1(react-dom@18.2.0)(react@18.2.0)
       p-limit: 3.1.0
       react: 18.2.0
@@ -7386,29 +7381,29 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /postcss-import@15.1.0(postcss@8.4.33):
+  /postcss-import@15.1.0(postcss@8.4.35):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
     dev: true
 
-  /postcss-js@4.0.1(postcss@8.4.33):
+  /postcss-js@4.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.33
+      postcss: 8.4.35
     dev: true
 
-  /postcss-load-config@4.0.2(postcss@8.4.33):
+  /postcss-load-config@4.0.2(postcss@8.4.35):
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -7421,17 +7416,17 @@ packages:
         optional: true
     dependencies:
       lilconfig: 3.0.0
-      postcss: 8.4.33
+      postcss: 8.4.35
       yaml: 2.3.4
     dev: true
 
-  /postcss-nested@6.0.1(postcss@8.4.33):
+  /postcss-nested@6.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-selector-parser: 6.0.15
     dev: true
 
@@ -7456,8 +7451,8 @@ packages:
       source-map-js: 1.0.2
     dev: false
 
-  /postcss@8.4.33:
-    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+  /postcss@8.4.35:
+    resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
@@ -7548,8 +7543,8 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-icons@4.12.0(react@18.2.0):
-    resolution: {integrity: sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==}
+  /react-icons@5.0.1(react@18.2.0):
+    resolution: {integrity: sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==}
     peerDependencies:
       react: '*'
     dependencies:
@@ -7881,8 +7876,8 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass@1.70.0:
-    resolution: {integrity: sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==}
+  /sass@1.71.1:
+    resolution: {integrity: sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
@@ -8362,11 +8357,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.33
-      postcss-import: 15.1.0(postcss@8.4.33)
-      postcss-js: 4.0.1(postcss@8.4.33)
-      postcss-load-config: 4.0.2(postcss@8.4.33)
-      postcss-nested: 6.0.1(postcss@8.4.33)
+      postcss: 8.4.35
+      postcss-import: 15.1.0(postcss@8.4.35)
+      postcss-js: 4.0.1(postcss@8.4.35)
+      postcss-load-config: 4.0.2(postcss@8.4.35)
+      postcss-nested: 6.0.1(postcss@8.4.35)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
       sucrase: 3.35.0
@@ -8587,7 +8582,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.33)
+      postcss-load-config: 4.0.2(postcss@8.4.35)
       resolve-from: 5.0.0
       rollup: 4.9.5
       source-map: 0.8.0-beta.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       cloudinary:
         specifier: ^1.37.3
         version: 1.41.3
+      clsx:
+        specifier: ^2.1.0
+        version: 2.1.0
       next:
         specifier: ^14.0.0
         version: 14.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.70.0)
@@ -59,6 +62,9 @@ importers:
       sass:
         specifier: ^1.63.6
         version: 1.70.0
+      tailwind-merge:
+        specifier: ^2.2.1
+        version: 2.2.1
     devDependencies:
       autoprefixer:
         specifier: ^10.4.16
@@ -76,8 +82,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@cloudinary-util/url-loader':
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 5.0.0-beta.1
+        version: 5.0.0-beta.1
       '@cloudinary-util/util':
         specifier: ^2.3.0
         version: 2.4.0
@@ -1346,6 +1352,14 @@ packages:
 
   /@cloudinary-util/url-loader@4.2.0:
     resolution: {integrity: sha512-fpCFqFPAN/f9Gt//25qLXNDYwy5EcOudRzDPOrsEBH6aMwEdFaJuPxvLiP0IP5MCihKji/XDr9QJQ9Wa+amNSA==}
+    dependencies:
+      '@cloudinary-util/util': 3.0.0
+      '@cloudinary/url-gen': 1.15.0
+      zod: 3.22.4
+    dev: false
+
+  /@cloudinary-util/url-loader@5.0.0-beta.1:
+    resolution: {integrity: sha512-ZIRG4qqmlHPTKHpxL07WTi3BwgaoAVkEHqnTxdWLSJmYDb8EWFzhJ341l0mpzQ40CLW21yfLm3kkoInvDHm/Tg==}
     dependencies:
       '@cloudinary-util/util': 3.0.0
       '@cloudinary/url-gen': 1.15.0
@@ -8322,6 +8336,12 @@ packages:
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
+
+  /tailwind-merge@2.2.1:
+    resolution: {integrity: sha512-o+2GTLkthfa5YUt4JxPfzMIpQzZ3adD1vLVkvKE1Twl9UAhGsEbIZhHHZVRttyW177S8PDJI3bTQNaebyofK3Q==}
+    dependencies:
+      '@babel/runtime': 7.23.8
+    dev: false
 
   /tailwindcss@3.4.1:
     resolution: {integrity: sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6760,7 +6760,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       sass: 1.70.0
-      styled-jsx: 5.1.1(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.23.7)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.0
       '@next/swc-darwin-x64': 14.1.0
@@ -8271,23 +8271,6 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.23.7
-      client-only: 0.0.1
-      react: 18.2.0
-    dev: false
-
-  /styled-jsx@5.1.1(react@18.2.0):
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-    dependencies:
       client-only: 0.0.1
       react: 18.2.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@cloudinary-util/url-loader':
-        specifier: 5.0.0-beta.1
-        version: 5.0.0-beta.1
+        specifier: 5.0.0-beta.2
+        version: 5.0.0-beta.2
       '@cloudinary-util/util':
         specifier: ^2.3.0
         version: 2.4.0
@@ -1358,8 +1358,8 @@ packages:
       zod: 3.22.4
     dev: false
 
-  /@cloudinary-util/url-loader@5.0.0-beta.1:
-    resolution: {integrity: sha512-ZIRG4qqmlHPTKHpxL07WTi3BwgaoAVkEHqnTxdWLSJmYDb8EWFzhJ341l0mpzQ40CLW21yfLm3kkoInvDHm/Tg==}
+  /@cloudinary-util/url-loader@5.0.0-beta.2:
+    resolution: {integrity: sha512-ucVlWgSwy5jGjMGxz/m8fGFoAFSxaFJkoc0lwbOS2vA+lwSzeDQbiRHnA4V3dG9zuiizBVEs8RN83AhyYZlNAA==}
     dependencies:
       '@cloudinary-util/util': 3.0.0
       '@cloudinary/url-gen': 1.15.0
@@ -6760,7 +6760,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       sass: 1.70.0
-      styled-jsx: 5.1.1(@babel/core@7.23.7)(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.0
       '@next/swc-darwin-x64': 14.1.0
@@ -8271,6 +8271,23 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.23.7
+      client-only: 0.0.1
+      react: 18.2.0
+    dev: false
+
+  /styled-jsx@5.1.1(react@18.2.0):
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
       client-only: 0.0.1
       react: 18.2.0
     dev: false


### PR DESCRIPTION
# Description

This removes the 2-stage image sizing that occurs on URLs generated via the image component and helpers to avoid producing lower resolution images that necessary for images with a larger original source.

Instead, this primarily provides a post-transformation resize mechanism and a new `crop` API that provides the ability to customize how crops are applied.

In an original example of:
```
<CldImage width height crop="fill" ... />
```

The resulting URL may look like:

```
/w_width,h_height,c_fill/transformations/w_width,c_limit/
```

This would always restrict the resulting image from being no larger than the initial width, which is based on the desired render size, not the original image's source size.

With the new crop API, by using:
```
<CldImage width height crop="fill" ... />
```

The resulting URL may look like:

```
transformations/w_width,h_height,c_fill/
```

And to replicate the original 2-stage effect, you can do:

```
<CldImage width height crop={{ type: 'fill', source: true }} ... />
```

Where the resulting URL may look like:

```
/w_width,h_height,c_fill/transformations/w_width,c_limit/
```

Please see the RFC for more context and reasoning: https://github.com/cloudinary-community/next-cloudinary/discussions/432