### PR TITLE
Fixes auto format and quality overriding raw transformations configuration

### DIFF
--- a/docs/pages/cldimage/configuration.mdx
+++ b/docs/pages/cldimage/configuration.mdx
@@ -1866,6 +1866,11 @@ namedTransformations={['my-transformation']}
 Preserves transformations already applied to an image when passing in a Cloudinary URL
 as the `src`.
 
+> Note: The Cloudinary URL requires a version number (ex: `/v1234/`) in order to be parsed.
+
+When using this option, the transformations will be parsed from a valid URL and then
+be applied as [rawTransformations](#rawtransformations).
+
 **Examples**
 
 ```jsx copy
@@ -1875,7 +1880,11 @@ preserveTransformations
 #### `rawTransformations`
 
 Provides the ability to pass in an array of "raw" Cloudinary transformations using the
-[Transformation URL API](https://cloudinary.com/documentation/transformation_reference)
+[Transformation URL API](https://cloudinary.com/documentation/transformation_reference).
+
+When using this option, if a format (`f_`) or quality (`q_`) is detected in the applied
+transformations, the respective option will not be applied automatically unless explicitly
+configured on the component using the [format](#format) or [quality](#quality) options.
 
 **Examples**
 
@@ -2003,7 +2012,7 @@ Controls the quality of the delivered asset. Reducing the quality is a trade-off
 **Examples**
 
 ```jsx copy
-quality="10"
+quality={10}
 ```
 
 [Learn more about quality](https://cloudinary.com/documentation/transformation_reference#q_quality) on the Cloudinary docs.

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@cloudinary-util/types": "1.0.0",
-    "@cloudinary-util/url-loader": "5.1.1",
+    "@cloudinary-util/url-loader": "5.2.0",
     "@cloudinary-util/util": "^3.0.0",
     "@tsconfig/recommended": "^1.0.3"
   },

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@cloudinary-util/types": "1.0.0",
-    "@cloudinary-util/url-loader": "5.2.0",
+    "@cloudinary-util/url-loader": "5.2.1",
     "@cloudinary-util/util": "^3.0.0",
     "@tsconfig/recommended": "^1.0.3"
   },

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -237,7 +237,7 @@ describe('Cloudinary Loader', () => {
 
       const result = cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldConfig });
 
-      expect(result).toContain(`image/upload/${cldOptions.rawTransformations.join('/')}/c_limit,w_${imageProps.width}/f_auto/q_auto/v1/${imageProps.src}`)
+      expect(result).toContain(`image/upload/${cldOptions.rawTransformations.join('/')}/c_limit,w_${imageProps.width}/v1/${imageProps.src}`)
     });
 
     it('should return a Cloudinary URL from a Cloudinary URL source with spaces', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@cloudinary-util/url-loader':
-        specifier: 5.2.0
-        version: 5.2.0
+        specifier: 5.2.1
+        version: 5.2.1
       '@cloudinary-util/util':
         specifier: ^3.0.0
         version: 3.0.0
@@ -1316,8 +1316,8 @@ packages:
       zod: 3.22.4
     dev: false
 
-  /@cloudinary-util/url-loader@5.2.0:
-    resolution: {integrity: sha512-Z2BXTICLajx5M9XuJfCjGUwoIkVqtbksroprLkc4w1VHmWiq/HiueRpXWH5vu9yBVEgrj9Dn4eFk5xdGeH1Agg==}
+  /@cloudinary-util/url-loader@5.2.1:
+    resolution: {integrity: sha512-1GDPCnRYSGlnPqEdcvH/1h0puAYoF9tJazV/zNx3ptCN0PbwBWEw+ksZm6mCQF2cr9ofDE3B+C5YdPLLsvbuQQ==}
     dependencies:
       '@cloudinary-util/util': 3.0.0
       '@cloudinary/url-gen': 1.15.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@cloudinary-util/url-loader':
-        specifier: 5.1.1
-        version: 5.1.1
+        specifier: 5.2.0
+        version: 5.2.0
       '@cloudinary-util/util':
         specifier: ^3.0.0
         version: 3.0.0
@@ -1316,8 +1316,8 @@ packages:
       zod: 3.22.4
     dev: false
 
-  /@cloudinary-util/url-loader@5.1.1:
-    resolution: {integrity: sha512-M1l2Q51rOPdBKZs09rd22zw5UdGb/39FqxikRvc8i/7Mt0VDrqlvsc8FhDguhJJwV/YxfhNvJOAdGqp/ErEv4w==}
+  /@cloudinary-util/url-loader@5.2.0:
+    resolution: {integrity: sha512-Z2BXTICLajx5M9XuJfCjGUwoIkVqtbksroprLkc4w1VHmWiq/HiueRpXWH5vu9yBVEgrj9Dn4eFk5xdGeH1Agg==}
     dependencies:
       '@cloudinary-util/util': 3.0.0
       '@cloudinary/url-gen': 1.15.0


### PR DESCRIPTION
# Description

Updates URL Loader to pull in a fix that prevents the defaults of format auto and quality auto from overriding those options being present in a raw transformation.

Example use case is parsing a cloudinary URL as the src that already contains a format (ex: f_gif), where if the format and quality of auto are later applied, would prevent the asset from being rendered as a gif.