### PR TITLE
Fixes quality type of CldImage component

### DIFF
--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -9,7 +9,7 @@ import { getCldImageUrl } from '../../helpers/getCldImageUrl';
 
 import { cloudinaryLoader } from '../../loaders/cloudinary-loader';
 
-export type CldImageProps = Omit<ImageProps, 'src'> & ImageOptions & {
+export type CldImageProps = Omit<ImageProps, 'src' | 'quality'> & ImageOptions & {
   config?: ConfigOptions;
   preserveTransformations?: boolean;
   src: string;


### PR DESCRIPTION
# Description

Omit quality type from `ImageProps` of next/image to avoid type conflict

## Issue Ticket Number

Fixes #449 


## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
