### PR TITLE
Secure Distribution / Cname Environment Variables, CldVideoPlayer Config

### DIFF
--- a/docs/pages/cldimage/configuration.mdx
+++ b/docs/pages/cldimage/configuration.mdx
@@ -1617,7 +1617,7 @@ Allows configuration for the Cloudinary environment.
 ```jsx copy
 config={{
   cloud: {
-    cloudName: 'my-cloud'
+    cloudName: '<Your Cloud Name>',
   }
 }}
 ```

--- a/docs/pages/clduploadwidget/configuration.mdx
+++ b/docs/pages/clduploadwidget/configuration.mdx
@@ -17,7 +17,7 @@ import Table from '../../components/Table';
 
 # CldUploadWidget Configuration
 
-## Configuration
+## Basic Props
 
 <Table
   columns={[
@@ -42,12 +42,6 @@ import Table from '../../components/Table';
       prop: 'children',
       type: 'function',
       example: () => (<code>{`{(options) => {}}`}</code>),
-    },
-    {
-      prop: 'options',
-      type: 'object',
-      example: () => (<code>{`{encryption: {...}}`}</code>),
-      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#parameters">More Info</a>)
     },
     {
       prop: 'signatureEndpoint',
@@ -80,20 +74,68 @@ A function that returns a React component that receives instance methods and opt
 </CldUploadWidget>
 ```
 
-### `options`
+#### Parameters
 
-Parameters used to customize and configure the Upload Widget instance. These options are passed in
-directly to the Upload Widget, exposing all available parameters through the `options` object.
+By passing in a function as the child of the Upload Widget, you're able to gain access to the widget, results, and instance methods to interface directly with the widget.
+
+<Table
+  columns={[
+    {
+      id: 'prop',
+      title: 'Prop'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'description',
+      title: 'Description'
+    },
+  ]}
+  data={[
+    {
+      prop: 'cloudinary',
+      type: 'Cloudinary',
+      description: 'The Cloudinary instance which creates and manages the Widget instance.'
+    },
+    {
+      prop: 'error',
+      type: 'string',
+      description: 'The error, if any, produced by an upload widget action.'
+    },
+    {
+      prop: 'isLoading',
+      type: 'boolean',
+      description: 'Designates whether the upload widget is loading and initializing.'
+    },
+    {
+      prop: 'results',
+      type: 'object',
+      description: 'The event that triggered the results and information related to that event, which can include upload results.'
+    },
+    {
+      prop: 'widget',
+      type: 'Widget',
+      description: 'The widget instance attached to the current component.'
+    },
+    {
+      prop: '[Instance Methods]',
+      type: 'Function',
+      description: () => (<span>See <a href="#instance-methods">Instance Methods</a> below</span>)
+    },
+  ]}
+/>
+
+**Example**
 
 ```jsx copy showLineNumbers
-options={{
-  sources: ['local', 'url', 'unsplash'],
-  multiple: true,
-  maxFiles: 5
-}}
+<CldUploadWidget>
+  {({ cloudinary, widget, open }) => {
+    // Return UI
+  }}
+</CldUploadWidget>
 ```
-
-[Learn more about Upload Widget parameters](https://cloudinary.com/documentation/upload_widget_reference#parameters) on the Cloudinary docs.
 
 ### `signatureEndpoint`
 
@@ -115,6 +157,8 @@ uploadPreset="my-upload-preset"
 
 
 ## Events
+
+### Callback Functions
 
 <Table
   columns={[
@@ -378,69 +422,6 @@ from the resulting event. If the result is a resource, the shape will include so
 }
 ```
 
-## Child Function Parameters
-
-By passing in a function as the child of the Upload Widget, you're able to gain access to the widget, results, and instance methods to interface directly with the widget.
-
-<Table
-  columns={[
-    {
-      id: 'prop',
-      title: 'Prop'
-    },
-    {
-      id: 'type',
-      title: 'Type'
-    },
-    {
-      id: 'description',
-      title: 'Description'
-    },
-  ]}
-  data={[
-    {
-      prop: 'cloudinary',
-      type: 'Cloudinary',
-      description: 'The Cloudinary instance which creates and manages the Widget instance.'
-    },
-    {
-      prop: 'error',
-      type: 'string',
-      description: 'The error, if any, produced by an upload widget action.'
-    },
-    {
-      prop: 'isLoading',
-      type: 'boolean',
-      description: 'Designates whether the upload widget is loading and initializing.'
-    },
-    {
-      prop: 'results',
-      type: 'object',
-      description: 'The event that triggered the results and information related to that event, which can include upload results.'
-    },
-    {
-      prop: 'widget',
-      type: 'Widget',
-      description: 'The widget instance attached to the current component.'
-    },
-    {
-      prop: '[Instance Methods]',
-      type: 'Function',
-      description: () => (<span>See <a href="#instance-methods">Instance Methods</a> below</span>)
-    },
-  ]}
-/>
-
-**Example**
-
-```jsx copy showLineNumbers
-<CldUploadWidget>
-  {({ cloudinary, widget, open }) => {
-    // Return UI
-  }}
-</CldUploadWidget>
-```
-
 ## Instance Methods
 
 The Upload Widget exposes instance methods that gives the ability to have greater control and flexbility over
@@ -516,3 +497,76 @@ They're exposed either through event handler callback or child function paramete
     },
   ]}
 />
+
+## Advanced
+
+### Configuration
+
+<Table
+  columns={[
+    {
+      id: 'prop',
+      title: 'Prop'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'default',
+      title: 'Default'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    }
+  ]}
+  data={[
+    {
+      prop: 'config',
+      type: 'object',
+      default: '-',
+      example: () => (<code>{`{ url: { cloudName: 'spacejelly' } }`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters">More Info</a>)
+    },
+    {
+      prop: 'options',
+      type: 'object',
+      example: () => (<code>{`{encryption: {...}}`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#parameters">More Info</a>)
+    },
+  ]}
+/>
+
+#### `config`
+
+Allows configuration for the Cloudinary environment.
+
+**Examples**
+
+```jsx copy
+config={{
+  cloud: {
+    cloudName: '<Your Cloud Name>',
+    apiKey: '<Your API Key>'
+  }
+}}
+```
+
+#### `options`
+
+Parameters used to customize and configure the Upload Widget instance. These options are passed in
+directly to the Upload Widget, exposing all available parameters through the `options` object.
+
+```jsx copy showLineNumbers
+options={{
+  sources: ['local', 'url', 'unsplash'],
+  multiple: true,
+  maxFiles: 5
+}}
+```
+
+[Learn more about Upload Widget parameters](https://cloudinary.com/documentation/upload_widget_reference#parameters) on the Cloudinary docs.

--- a/docs/pages/cldvideoplayer/configuration.mdx
+++ b/docs/pages/cldvideoplayer/configuration.mdx
@@ -243,7 +243,6 @@ Allows configuration for the Cloudinary environment.
 config={{
   cloud: {
     cloudName: '<Your Cloud Name>',
-    apiKey: '<Your API Key>'
   }
 }}
 ```

--- a/docs/pages/cldvideoplayer/configuration.mdx
+++ b/docs/pages/cldvideoplayer/configuration.mdx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 
 import OgImage from '../../components/OgImage';
+import Table from '../../components/Table';
 
 <Head>
   <title>CldVideoPlayer Configuration - Next Cloudinary</title>
@@ -94,17 +95,6 @@ import OgImage from '../../components/OgImage';
 
 Missing an option from the [Video Player docs](https://cloudinary.com/documentation/video_player_api_reference) you'd like to see? [Create an issue](https://github.com/cloudinary-community/next-cloudinary/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=%5BFeature%5D+)!
 
-## Config & Delivery
-
-| Prop Name          | Type           | Default         | Description                              | Example                      |
-|--------------------|----------------|-----------------|------------------------------------------|------------------------------|
-| cname              | string         | -               | The custom domain name (CNAME) to use for building URLs, requires secure: false. | mycname.com |
-| privateCdn         | boolean        | false           | Set this parameter to true if you are an Advanced plan user with a private CDN distribution | `true` |
-| secureDistribution | string         | -               | The custom domain name (CNAME) to use for building URLs, requires secure: true. | mycname.com |
-| queryParams        | string/object  | -               | Query parameters to append to video URL | `{myParam: 'value'}` |
-
-Missing an option from the [Video Player docs](https://cloudinary.com/documentation/video_player_api_reference) you'd like to see? [Create an issue](https://github.com/cloudinary-community/next-cloudinary/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=%5BFeature%5D+)!
-
 ## Customization
 
 ### Logo
@@ -180,4 +170,122 @@ To do this, create a new Ref instance and pass that in as the value of the prop:
 const myVideoRef = useRef();
 ...
 <CldVideoPlayer videoRef={myVideoRef} ... />
+```
+
+## Advanced
+
+### Configuration & Delivery
+
+<Table
+  columns={[
+    {
+      id: 'prop',
+      title: 'Prop'
+    },
+    {
+      id: 'type',
+      title: 'Type'
+    },
+    {
+      id: 'default',
+      title: 'Default'
+    },
+    {
+      id: 'example',
+      title: 'Example'
+    },
+    {
+      id: 'more'
+    }
+  ]}
+  data={[
+    {
+      prop: 'config',
+      type: 'object',
+      default: '-',
+      example: () => (<code>{`{ url: { cloudName: 'spacejelly' } }`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters">More Info</a>)
+    },
+    {
+      prop: 'cname',
+      type: 'string',
+      example: () => (<code>{`spacejelly.dev`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters">More Info</a>)
+    },
+    {
+      prop: 'privateCdn',
+      type: 'boolean',
+      example: () => (<code>{`true`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters">More Info</a>)
+    },
+    {
+      prop: 'secureDistribution',
+      type: 'string',
+      example: () => (<code>{`spacejelly.dev`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters">More Info</a>)
+    },
+    {
+      prop: 'queryParams',
+      type: 'string/object',
+      example: () => (<code>{`{myParam: 'value'}`}</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters">More Info</a>)
+    },
+  ]}
+/>
+
+#### `config`
+
+Allows configuration for the Cloudinary environment.
+
+**Examples**
+
+```jsx copy
+config={{
+  cloud: {
+    cloudName: '<Your Cloud Name>',
+    apiKey: '<Your API Key>'
+  }
+}}
+```
+
+#### `cname`
+
+The custom domain name (CNAME) to use for building URLs, requires secure: false.
+
+**Examples**
+
+```jsx copy
+cname="spacejelly.dev"
+```
+
+#### `privateCdn`
+
+Set this parameter to true if you are an Advanced plan user with a private CDN distribution
+
+**Examples**
+
+```jsx copy
+privateCdn={true}
+```
+
+#### `secureDistribution`
+
+The custom domain name (CNAME) to use for building URLs, requires secure: true.
+
+**Examples**
+
+```jsx copy
+secureDistribution="spacejelly.dev"
+```
+
+#### `queryParams`
+
+Query parameters to append to video URL.
+
+**Examples**
+
+```jsx copy
+queryParams={{
+  myParam: 'value'
+}}
 ```

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -58,7 +58,32 @@ Don't have a Cloudinary account? <a href="https://cloudinary.com/users/register_
 
 </Steps>
 
-You can find more detailed instructions for components that may require other configuration such as an API key on the component's Basic Usage page.
+If using the Cloudinary Upload Widget and using Signed Uploads, you'll likely also want to also set
+your Cloudinary API Key and API Secret.
+
+```ansi copy
+NEXT_PUBLIC_CLOUDINARY_API_KEY="<Your API Key>"
+CLOUDINARY_API_SECRET="<Your API Secret>"
+```
+
+The API Key is a publicly available value where the Secret must be kept private only to be used on the server.
+
+## Global Configuration
+
+Here are all of the available configurable environment variables for Next Cloudinary:
+
+<Callout emoji={false}>
+  Note: These are not all required to use the library.
+</Callout>
+
+```ansi copy
+NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME="<Your Cloud Name>"
+NEXT_PUBLIC_CLOUDINARY_API_KEY="<Your API Key>"
+CLOUDINARY_API_SECRET="<Your API Secret>"
+
+NEXT_PUBLIC_CLOUDINARY_SECURE_DISTRIBUTION="<Your Secure Distribution / CNAME>"
+NEXT_PUBLIC_CLOUDINARY_PRIVATE_CDN="<true|false>"
+```
 
 ## Using Next Cloudinary
 

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -19,7 +19,7 @@ import {
   CldUploadWidgetWidgetInstance,
 } from './CldUploadWidget.types';
 
-import {checkForCloudName} from "../../lib/cloudinary";
+import { getCloudinaryConfig } from "../../lib/cloudinary";
 
 const WIDGET_WATCHED_EVENTS = [
   'success',
@@ -43,6 +43,7 @@ const WIDGET_EVENTS: { [key: string]: string } = {
 
 const CldUploadWidget = ({
   children,
+  config,
   onError,
   onOpen,
   onUpload,
@@ -65,15 +66,15 @@ const CldUploadWidget = ({
   // either on page load or during the upload process. Read more about signed uploads at:
   // https://cloudinary.com/documentation/upload_widget#signed_uploads
 
+  const cloudinaryConfig = getCloudinaryConfig(config);
+  const { cloudName, apiKey } = cloudinaryConfig?.cloud;
+
   const uploadOptions = {
-    cloudName: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
+    cloudName,
     uploadPreset: uploadPreset || process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET,
-    apiKey: process.env.NEXT_PUBLIC_CLOUDINARY_API_KEY,
+    apiKey,
     ...options,
   };
-
-  //Check if Cloud Name exists
-  checkForCloudName(process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME);
 
   if ( signed ) {
     uploadOptions.uploadSignature = generateSignature;

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -4,12 +4,14 @@ import {
   CloudinaryUploadWidgetInstanceMethods,
   CloudinaryUploadWidgetError
 } from '@cloudinary-util/types';
+import { ConfigOptions } from "@cloudinary-util/url-loader";
 
 export type CldUploadWidgetCloudinaryInstance = any;
 export type CldUploadWidgetWidgetInstance = any;
 
 export interface CldUploadWidgetProps {
   children?: ({ cloudinary, widget, open, results, error }: CldUploadWidgetPropsChildren) => JSX.Element;
+  config?: ConfigOptions;
   onError?: CldUploadEventCallbackError;
   onOpen?: CldUploadEventCallbackWidgetOnly;
   /**

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -8,7 +8,7 @@ import { CldVideoPlayerProps } from './CldVideoPlayer.types';
 
 import { getCldImageUrl } from '../../helpers/getCldImageUrl';
 import { getCldVideoUrl } from '../../helpers/getCldVideoUrl';
-import {checkForCloudName} from "../../lib/cloudinary";
+import { getCloudinaryConfig } from "../../lib/cloudinary";
 
 let playerInstances: string[] = [];
 
@@ -20,6 +20,7 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
     autoplay,
     className,
     colors,
+    config,
     controls = true,
     fontFace,
     height,
@@ -114,9 +115,6 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
     }
   }
 
-  //Check if Cloud Name exists
-  checkForCloudName(process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME);
-
   /**
    * handleOnLoad
    * @description Stores the Cloudinary window instance to a ref when the widget script loads
@@ -153,11 +151,17 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
         autoplayModeValue = autoplay;
       }
 
+      const cloudinaryConfig = getCloudinaryConfig(config);
+      const { cloudName } = cloudinaryConfig?.cloud;
+      const { secureDistribution, privateCdn } = cloudinaryConfig?.url;
 
       let playerOptions: CloudinaryVideoPlayerOptions = {
+        cloud_name: cloudName,
+        privateCdn,
+        secureDistribution,
+
         autoplayMode: autoplayModeValue,
         autoplay: autoPlayValue,
-        cloud_name: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
         controls,
         fontFace: fontFace || '',
         language,

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.types.ts
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.types.ts
@@ -4,12 +4,14 @@ import {
   CloudinaryVideoPlayerOptionsLogo,
   CloudinaryVideoPlayerOptions
 } from '@cloudinary-util/types';
+import { ConfigOptions } from "@cloudinary-util/url-loader";
 
 import { GetCldImageUrlOptions } from '../../helpers/getCldImageUrl';
 import { GetCldVideoUrlOptions } from '../../helpers/getCldVideoUrl';
 
 export type CldVideoPlayerProps = Omit<CloudinaryVideoPlayerOptions, "cloud_name" | "autoplayMode" | "publicId" | "secure" | "showLogo" | "logoImageUrl" | "logoOnclickUrl"> & {
   className?: string;
+  config?: ConfigOptions;
   id?: string;
   logo?: boolean | CldVideoPlayerPropsLogo;
   onDataLoad?: Function;

--- a/next-cloudinary/src/helpers/getCldImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldImageUrl.ts
@@ -1,8 +1,7 @@
 import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
 import type { ImageOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-util/url-loader';
 
-import { NEXT_CLOUDINARY_ANALYTICS_PRODUCT_ID, NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
-import {checkForCloudName} from "../lib/cloudinary";
+import { getCloudinaryConfig, getCloudinaryAnalytics } from "../lib/cloudinary";
 
 /**
  * getCldImageUrl
@@ -13,22 +12,9 @@ export type GetCldImageUrlConfig = ConfigOptions;
 export type GetCldImageUrlAnalytics = AnalyticsOptions;
 
 export function getCldImageUrl(options: GetCldImageUrlOptions, config?: GetCldImageUrlConfig, analytics?: GetCldImageUrlAnalytics) {
-  // @ts-expect-error Property 'cloud' does not exist on type 'CloudinaryConfigurationOptions'.
-  const cloudName = config?.cloud?.cloudName ?? process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
-  checkForCloudName(cloudName);
   return constructCloudinaryUrl({
     options,
-    config: Object.assign({
-      cloud: {
-        cloudName: cloudName
-      },
-    }, config),
-    analytics: Object.assign({
-      product: NEXT_CLOUDINARY_ANALYTICS_PRODUCT_ID,
-      sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
-      sdkSemver: NEXT_CLOUDINARY_VERSION,
-      techVersion: NEXT_VERSION,
-      feature: ''
-    }, analytics)
+    config: getCloudinaryConfig(config),
+    analytics: getCloudinaryAnalytics(analytics)
   });
 }

--- a/next-cloudinary/src/helpers/getCldVideoUrl.ts
+++ b/next-cloudinary/src/helpers/getCldVideoUrl.ts
@@ -1,8 +1,7 @@
 import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
 import type { VideoOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-util/url-loader';
 
-import { NEXT_CLOUDINARY_ANALYTICS_PRODUCT_ID, NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
-import {checkForCloudName} from "../lib/cloudinary";
+import { getCloudinaryConfig, getCloudinaryAnalytics } from "../lib/cloudinary";
 
 /**
  * getCldVideoUrl
@@ -13,25 +12,12 @@ export type GetCldVideoUrlConfig = ConfigOptions;
 export type GetCldVideoUrlAnalytics = AnalyticsOptions;
 
 export function getCldVideoUrl(options: GetCldVideoUrlOptions, config?: GetCldVideoUrlConfig, analytics?: GetCldVideoUrlAnalytics) {
-  // @ts-expect-error Property 'cloud' does not exist on type 'CloudinaryConfigurationOptions'.
-  const cloudName = config?.cloud?.cloudName ?? process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
-  checkForCloudName(cloudName);
   return constructCloudinaryUrl({
     options: {
       assetType: 'video',
       ...options
     },
-    config: Object.assign({
-      cloud: {
-        cloudName: cloudName
-      },
-    }, config),
-    analytics: Object.assign({
-      product: NEXT_CLOUDINARY_ANALYTICS_PRODUCT_ID,
-      sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
-      sdkSemver: NEXT_CLOUDINARY_VERSION,
-      techVersion: NEXT_VERSION,
-      feature: ''
-    }, analytics)
+    config: getCloudinaryConfig(config),
+    analytics: getCloudinaryAnalytics(analytics)
   });
 }

--- a/next-cloudinary/src/lib/cloudinary.ts
+++ b/next-cloudinary/src/lib/cloudinary.ts
@@ -44,7 +44,7 @@ export function checkForCloudName(cloudName: string | undefined) {
  * getCloudinaryConfig
  */
 
-export function getCloudinaryConfig(config: ConfigOptions = {}) {
+export function getCloudinaryConfig(config?: ConfigOptions) {
   const cloudName = config?.cloud?.cloudName ?? process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
 
   if (!cloudName) {
@@ -56,11 +56,11 @@ export function getCloudinaryConfig(config: ConfigOptions = {}) {
 
   return Object.assign({
     cloud: {
-      ...config.cloud,
+      ...config?.cloud,
       cloudName: cloudName
     },
     url: {
-      ...config.url,
+      ...config?.url,
       secureDistribution,
       privateCdn
     }
@@ -71,7 +71,7 @@ export function getCloudinaryConfig(config: ConfigOptions = {}) {
  * getCloudinaryAnalytics
  */
 
-export function getCloudinaryAnalytics(analytics: AnalyticsOptions) {
+export function getCloudinaryAnalytics(analytics?: AnalyticsOptions) {
   return Object.assign({
     product: NEXT_CLOUDINARY_ANALYTICS_PRODUCT_ID,
     sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,

--- a/next-cloudinary/src/lib/cloudinary.ts
+++ b/next-cloudinary/src/lib/cloudinary.ts
@@ -1,3 +1,7 @@
+import { AnalyticsOptions, ConfigOptions } from "@cloudinary-util/url-loader";
+
+import { NEXT_CLOUDINARY_ANALYTICS_PRODUCT_ID, NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
+
 /**
  * pollForProcessingImage
  */
@@ -34,4 +38,45 @@ export function checkForCloudName(cloudName: string | undefined) {
   if (!cloudName) {
     throw new Error('A Cloudinary Cloud name is required, please make sure NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME is set and configured in your environment.');
   }
+}
+
+/**
+ * getCloudinaryConfig
+ */
+
+export function getCloudinaryConfig(config: ConfigOptions = {}) {
+  const cloudName = config?.cloud?.cloudName ?? process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+
+  if (!cloudName) {
+    throw new Error('A Cloudinary Cloud name is required, please make sure NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME is set and configured in your environment.');
+  }
+
+  const secureDistribution = config?.url?.secureDistribution ?? process.env.NEXT_PUBLIC_CLOUDINARY_SECURE_DISTRIBUTION;
+  const privateCdn = config?.url?.privateCdn ?? process.env.NEXT_PUBLIC_CLOUDINARY_PRIVATE_CDN;
+
+  return Object.assign({
+    cloud: {
+      ...config.cloud,
+      cloudName: cloudName
+    },
+    url: {
+      ...config.url,
+      secureDistribution,
+      privateCdn
+    }
+  }, config);
+}
+
+/**
+ * getCloudinaryAnalytics
+ */
+
+export function getCloudinaryAnalytics(analytics: AnalyticsOptions) {
+  return Object.assign({
+    product: NEXT_CLOUDINARY_ANALYTICS_PRODUCT_ID,
+    sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
+    sdkSemver: NEXT_CLOUDINARY_VERSION,
+    techVersion: NEXT_VERSION,
+    feature: ''
+  }, analytics)
 }

--- a/next-cloudinary/src/lib/cloudinary.ts
+++ b/next-cloudinary/src/lib/cloudinary.ts
@@ -34,12 +34,6 @@ export async function pollForProcessingImage(options: PollForProcessingImageOpti
   return true;
 }
 
-export function checkForCloudName(cloudName: string | undefined) {
-  if (!cloudName) {
-    throw new Error('A Cloudinary Cloud name is required, please make sure NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME is set and configured in your environment.');
-  }
-}
-
 /**
  * getCloudinaryConfig
  */
@@ -51,13 +45,15 @@ export function getCloudinaryConfig(config?: ConfigOptions) {
     throw new Error('A Cloudinary Cloud name is required, please make sure NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME is set and configured in your environment.');
   }
 
+  const apiKey = config?.cloud?.apiKey ?? process.env.NEXT_PUBLIC_CLOUDINARY_API_KEY;
   const secureDistribution = config?.url?.secureDistribution ?? process.env.NEXT_PUBLIC_CLOUDINARY_SECURE_DISTRIBUTION;
   const privateCdn = config?.url?.privateCdn ?? process.env.NEXT_PUBLIC_CLOUDINARY_PRIVATE_CDN;
 
   return Object.assign({
     cloud: {
       ...config?.cloud,
-      cloudName: cloudName
+      apiKey,
+      cloudName
     },
     url: {
       ...config?.url,

--- a/next-cloudinary/tests/helpers/getCldImageUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldImageUrl.spec.js
@@ -29,4 +29,24 @@ describe('Cloudinary', () => {
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
     });
   });
+
+  describe('Config', () => {
+    it('should configure a cname via secure distribution environment variables', () => {
+      const cloudName = 'customtestcloud';
+      const secureDistrubtion = 'mywebsite.dev';
+      const privateCdn = true;
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+      process.env.NEXT_PUBLIC_CLOUDINARY_SECURE_DISTRIBUTION = secureDistrubtion;
+      process.env.NEXT_PUBLIC_CLOUDINARY_PRIVATE_CDN = privateCdn;
+
+      const url = getCldImageUrl({
+        src: 'turtle',
+        width: 100,
+        height: 100
+      });
+
+      expect(url).toContain(`https://${secureDistrubtion}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+    });
+  });
 })

--- a/next-cloudinary/tests/helpers/getCldVideoUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldVideoUrl.spec.js
@@ -29,4 +29,24 @@ describe('Cloudinary', () => {
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/video/upload/c_limit,w_100/f_auto/q_auto/turtle`);
     });
   });
+
+  describe('Config', () => {
+    it('should configure a cname via secure distribution environment variables', () => {
+      const cloudName = 'customtestcloud';
+      const secureDistrubtion = 'mywebsite.dev';
+      const privateCdn = true;
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+      process.env.NEXT_PUBLIC_CLOUDINARY_SECURE_DISTRIBUTION = secureDistrubtion;
+      process.env.NEXT_PUBLIC_CLOUDINARY_PRIVATE_CDN = privateCdn;
+
+      const url = getCldVideoUrl({
+        src: 'turtle',
+        width: 100,
+        height: 100
+      });
+
+      expect(url).toContain(`https://${secureDistrubtion}/video/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+    });
+  });
 })

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -294,7 +294,6 @@ describe('Cloudinary Loader', () => {
 
         expect(result).toContain(`https://${config.url.secureDistribution}/${cldConfig.cloud.cloudName}/image/upload`)
       });
-
     });
   })
 });


### PR DESCRIPTION
# Description

* Global cname/secure distribution
* CldVideoPlayer config prop
* CldUploadWidget config prop

Adds the ability to configure an environment variable for global cname/secure distribution configuration

```
NEXT_PUBLIC_CLOUDINARY_SECURE_DISTRIBUTION="spacejelly.dev"
NEXT_PUBLIC_CLOUDINARY_PRIVATE_CDN=true
```

Currently opting **not** to provide an option for the `cname` parameter as that's considered legacy and only used for insecure contexts, which is not recommended

See: https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters

Adds config prop to CldVideoPlayer and CldUploadWidget for individual configuration. This also inherits the global configurations as relevant.

## Issue Ticket Number

Fixes #465 
Fixes #464