### PR TITLE
Fixes getCldVideoUrl Safari Bug

### DIFF
--- a/next-cloudinary/src/helpers/getCldVideoUrl.ts
+++ b/next-cloudinary/src/helpers/getCldVideoUrl.ts
@@ -15,6 +15,7 @@ export function getCldVideoUrl(options: GetCldVideoUrlOptions, config?: GetCldVi
   return constructCloudinaryUrl({
     options: {
       assetType: 'video',
+      format: 'auto:video',
       ...options
     },
     config: getCloudinaryConfig(config),

--- a/next-cloudinary/tests/helpers/getCldVideoUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldVideoUrl.spec.js
@@ -26,7 +26,7 @@ describe('Cloudinary', () => {
         height: 100
       });
 
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/video/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/video/upload/c_limit,w_100/f_auto:video/q_auto/turtle`);
     });
   });
 
@@ -46,7 +46,7 @@ describe('Cloudinary', () => {
         height: 100
       });
 
-      expect(url).toContain(`https://${secureDistrubtion}/video/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+      expect(url).toContain(`https://${secureDistrubtion}/video/upload/c_limit,w_100/f_auto:video/q_auto/turtle`);
     });
   });
 })


### PR DESCRIPTION
# Description

getCldVideoUrl was simply using `f_auto` for automatic format selection, but `f_auto` can default to an image

https://cloudinary.com/documentation/video_optimization#specifying_media_type_with_f_auto

This is what was happening in Safari, but by providing the hint of `f_auto:video` we can be sure it will return a video format.

## Issue Ticket Number

Fixes #467 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
