### PR TITLE
added onSuccessAction prop to Upload Widget

### DIFF
--- a/docs/pages/clduploadbutton/basic-usage.mdx
+++ b/docs/pages/clduploadbutton/basic-usage.mdx
@@ -47,7 +47,7 @@ export const UnsignedUpload = () => {
           setResource(result?.info);
           widget.close();
         }}
-        uploadPreset="next-cloudinary-unsigned"
+        uploadPreset="<Upload Preset>"
       />
       <p>URL: { resource?.secure_url }</p>
     </>

--- a/docs/pages/clduploadwidget/basic-usage.mdx
+++ b/docs/pages/clduploadwidget/basic-usage.mdx
@@ -70,7 +70,7 @@ export const UnsignedUpload = ({ options }) => {
   return (
     <div className={`grid gap-6 ${resource ? 'grid-cols-2' : 'grid-cols-1'}`}>
       <CldUploadWidget
-        uploadPreset="next-cloudinary-unsigned"
+        uploadPreset="<Your Upload Preset>"
         onSuccess={(result, { widget }) => {
           setResource(result?.info);
           widget.close();

--- a/docs/pages/clduploadwidget/configuration.mdx
+++ b/docs/pages/clduploadwidget/configuration.mdx
@@ -158,8 +158,14 @@ uploadPreset="my-upload-preset"
 
 ## Events
 
-The difference between the `Callback Functions` and the `Actions` is the second argument of options
-that the `Callback Functions` receive. The `Actions` only takes the results argument.
+Upload Widget events allow you to tap into different points of the upload lifecycle including
+when an upload has completed, but also when it starts the queue and more. To allow interaction with
+these events, CldUplodWidget provides both "Callback Functions" and "Actions".
+
+The difference between the Callback Functions and the Actions is the second argument of options
+that the Callback Functions receive. While Callback Functions pass in both the results along with the
+widget instance and instance methods, Actions only pass along the results in order to support the
+Server Actions workflow.
 
 ### Callback Functions
 

--- a/docs/pages/clduploadwidget/configuration.mdx
+++ b/docs/pages/clduploadwidget/configuration.mdx
@@ -158,6 +158,9 @@ uploadPreset="my-upload-preset"
 
 ## Events
 
+The difference between the `Callback Functions` and the `Actions` is the second argument of options
+that the `Callback Functions` receive. The `Actions` only takes the results argument.
+
 ### Callback Functions
 
 <Table
@@ -273,6 +276,109 @@ uploadPreset="my-upload-preset"
       more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#upload_added">More Info</a>)
     },
   ]}
+/>
+
+
+### Actions
+
+<Table
+    columns={[
+        {
+            id: 'prop',
+            title: 'Prop'
+        },
+        {
+            id: 'type',
+            title: 'Type'
+        },
+        {
+            id: 'example',
+            title: 'Example'
+        },
+        {
+            id: 'more',
+        },
+    ]}
+    data={[
+        {
+            prop: 'onAbortAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#abort">More Info</a>)
+        },
+        {
+            prop: 'onBatchCancelledAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#batch_cancelled">More Info</a>)
+        },
+        {
+            prop: 'onCloseAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#close_event">More Info</a>)
+        },
+        {
+            prop: 'onDisplayChangedAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#display_changed">More Info</a>)
+        },
+        {
+            prop: 'onPublicIdAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#publicid">More Info</a>)
+        },
+        {
+            prop: 'onQueuesEndAction',
+            type: 'function',
+            example: () => (<code>{`(results, options) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#queues_end">More Info</a>)
+        },
+        {
+            prop: 'onQueuesStartAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#queues_start">More Info</a>)
+        },
+        {
+            prop: 'onRetryAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#retry">More Info</a>)
+        },
+        {
+            prop: 'onShowCompletedAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#show_completed">More Info</a>)
+        },
+        {
+            prop: 'onSourceChangedAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#source_changed">More Info</a>)
+        },
+        {
+            prop: 'onSuccessAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#success">More Info</a>)
+        },
+        {
+            prop: 'onTagsAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#tags">More Info</a>)
+        },
+        {
+            prop: 'onUploadAddedAction',
+            type: 'function',
+            example: () => (<code>{`(results) => { }`}</code>),
+            more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/upload_widget_reference#upload_added">More Info</a>)
+        },
+    ]}
 />
 
 To learn more about the event callbacks and when they trigger, see: https://cloudinary.com/documentation/upload_widget_reference#events

--- a/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
+++ b/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
@@ -30,16 +30,21 @@ const CldUploadButton = ({
   options,
   signatureEndpoint,
   uploadPreset,
+  onAbortAction,
+  onBatchCancelledAction,
+  onCloseAction,
+  onDisplayChangedAction,
+  onPublicIdAction,
+  onQueuesEndAction,
+  onQueuesStartAction,
+  onRetryAction,
+  onShowCompletedAction,
+  onSourceChangedAction,
+  onSuccessAction,
+  onTagsAction,
+  onUploadAddedAction,
   ...props
 }: CldUploadButtonProps) => {
-
-  const actionProps = Object.keys(props)
-      .filter(key => key.endsWith('Action'))
-      .reduce((result, key) => {
-        //@ts-ignore
-        result[key] = props[key];
-        return result;
-      }, {});
 
   return (
     <>
@@ -47,7 +52,7 @@ const CldUploadButton = ({
         onError={onError}
         onOpen={onOpen}
         onUpload={onUpload}
-         onAbort={onAbort}
+        onAbort={onAbort}
         onBatchCancelled={onBatchCancelled}
         onClose={onClose}
         onDisplayChanged={onDisplayChanged}
@@ -63,7 +68,19 @@ const CldUploadButton = ({
         options={options}
         signatureEndpoint={signatureEndpoint}
         uploadPreset={uploadPreset}
-        {...actionProps}
+        onAbortAction={onAbortAction}
+        onBatchCancelledAction={onBatchCancelledAction}
+        onCloseAction={onCloseAction}
+        onDisplayChangedAction={onDisplayChangedAction}
+        onPublicIdAction={onPublicIdAction}
+        onQueuesEndAction={onQueuesEndAction}
+        onQueuesStartAction={onQueuesStartAction}
+        onRetryAction={onRetryAction}
+        onShowCompletedAction={onShowCompletedAction}
+        onSourceChangedAction={onSourceChangedAction}
+        onSuccessAction={onSuccessAction}
+        onTagsAction={onTagsAction}
+        onUploadAddedAction={onUploadAddedAction}
       >
         {({ open, isLoading }) => {
           function handleOnClick(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {

--- a/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
+++ b/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
@@ -14,7 +14,7 @@ const CldUploadButton = ({
   onError,
   onOpen,
   onUpload,
-  onAbort,
+   onAbort,
   onBatchCancelled,
   onClose,
   onDisplayChanged,
@@ -33,13 +33,21 @@ const CldUploadButton = ({
   ...props
 }: CldUploadButtonProps) => {
 
+  const actionProps = Object.keys(props)
+      .filter(key => key.endsWith('Action'))
+      .reduce((result, key) => {
+        //@ts-ignore
+        result[key] = props[key];
+        return result;
+      }, {});
+
   return (
     <>
       <CldUploadWidget
         onError={onError}
         onOpen={onOpen}
         onUpload={onUpload}
-        onAbort={onAbort}
+         onAbort={onAbort}
         onBatchCancelled={onBatchCancelled}
         onClose={onClose}
         onDisplayChanged={onDisplayChanged}
@@ -55,6 +63,7 @@ const CldUploadButton = ({
         options={options}
         signatureEndpoint={signatureEndpoint}
         uploadPreset={uploadPreset}
+        {...actionProps}
       >
         {({ open, isLoading }) => {
           function handleOnClick(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -13,6 +13,7 @@ import {
 import { triggerOnIdle } from '../../lib/util';
 
 import {
+  CldUploadEventAction,
   CldUploadEventCallback,
   CldUploadWidgetCloudinaryInstance,
   CldUploadWidgetProps,
@@ -253,7 +254,7 @@ const CldUploadWidget = ({
       }
 
       if ( typeof uploadResult?.event === 'string' ) {
-        if ( WIDGET_WATCHED_EVENTS.includes(uploadResult?.event) ) {
+        if ( WIDGET_WATCHED_EVENTS.includes(uploadResult?.event as string) ) {
           setResults(uploadResult);
         }
 
@@ -267,15 +268,11 @@ const CldUploadWidget = ({
           });
         }
 
-        if ( onSuccessAction && typeof props[`onSuccessAction`] === 'function' ) {
-          const formData = new FormData();
+        const widgetEventAction = `${widgetEvent}Action` as keyof typeof props;
 
-          Object.entries(uploadResult).forEach(([key, value]) => {
-            formData.append(key, JSON.stringify(value))
-          });
-          if (uploadResult.event === 'success') {
-            onSuccessAction(formData);
-          }
+        if ( widgetEventAction && typeof props[widgetEventAction] === 'function' ) {
+          const action = props[widgetEventAction] as CldUploadEventAction;
+          uploadResult.event === 'success' && action(uploadResult);
          }
       }
     });

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -26,7 +26,7 @@ const WIDGET_WATCHED_EVENTS = [
   'success',
 ];
 
-const WIDGET_EVENTS: { [key: string]: string } = {
+export const WIDGET_EVENTS: { [key: string]: string } = {
   'abort': 'onAbort',
   'batch-cancelled': 'onBatchCancelled',
   'close': 'onClose',
@@ -57,8 +57,6 @@ const CldUploadWidget = ({
   const widget: CldUploadWidgetWidgetInstance = useRef();
 
   const signed = !!signatureEndpoint;
-
-  const { onSuccessAction } = props;
 
   const [error, setError] = useState<CloudinaryUploadWidgetError | undefined>(undefined);
   const [results, setResults] = useState<CloudinaryUploadWidgetResults | undefined>(undefined);
@@ -272,7 +270,7 @@ const CldUploadWidget = ({
 
         if ( widgetEventAction && typeof props[widgetEventAction] === 'function' ) {
           const action = props[widgetEventAction] as CldUploadEventAction;
-          uploadResult.event === 'success' && action(uploadResult);
+          action(uploadResult);
          }
       }
     });

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -57,6 +57,8 @@ const CldUploadWidget = ({
 
   const signed = !!signatureEndpoint;
 
+  const { onSuccessAction } = props;
+
   const [error, setError] = useState<CloudinaryUploadWidgetError | undefined>(undefined);
   const [results, setResults] = useState<CloudinaryUploadWidgetResults | undefined>(undefined);
   const [isScriptLoading, setIsScriptLoading] = useState(true);
@@ -264,6 +266,17 @@ const CldUploadWidget = ({
             ...instanceMethods
           });
         }
+
+        if ( onSuccessAction && typeof props[`onSuccessAction`] === 'function' ) {
+          const formData = new FormData();
+
+          Object.entries(uploadResult).forEach(([key, value]) => {
+            formData.append(key, JSON.stringify(value))
+          });
+          if (uploadResult.event === 'success') {
+            onSuccessAction(formData);
+          }
+         }
       }
     });
   }

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -34,7 +34,6 @@ export interface CldUploadWidgetProps {
   options?: CloudinaryUploadWidgetOptions;
   signatureEndpoint?: URL | RequestInfo;
   uploadPreset?: string;
-  onSuccessAction?: CldUploadEventAction;
   onAbortAction?: CldUploadEventAction;
   onBatchCancelledAction?: CldUploadEventAction;
   onCloseAction?: CldUploadEventAction;
@@ -45,6 +44,7 @@ export interface CldUploadWidgetProps {
   onRetryAction?: CldUploadEventAction;
   onShowCompletedAction?: CldUploadEventAction;
   onSourceChangedAction?: CldUploadEventAction;
+  onSuccessAction?: CldUploadEventAction;
   onTagsAction?: CldUploadEventAction;
   onUploadAddedAction?: CldUploadEventAction;
 }

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -29,12 +29,25 @@ export interface CldUploadWidgetProps {
   onShowCompleted?: CldUploadEventCallback;
   onSourceChanged?: CldUploadEventCallback;
   onSuccess?: CldUploadEventCallback;
-  onSuccessAction?: (results: FormData) => void;
   onTags?: CldUploadEventCallback;
   onUploadAdded?: CldUploadEventCallback;
   options?: CloudinaryUploadWidgetOptions;
   signatureEndpoint?: URL | RequestInfo;
   uploadPreset?: string;
+  onSuccessAction?: CldUploadEventAction;
+  onUploadAction?: CldUploadEventAction;
+  onAbortAction?: CldUploadEventAction;
+  onBatchCancelledAction?: CldUploadEventAction;
+  onCloseAction?: CldUploadEventAction;
+  onDisplayChangedAction?: CldUploadEventAction;
+  onPublicIdAction?: CldUploadEventAction;
+  onQueuesEndAction?: CldUploadEventAction;
+  onQueuesStartAction?: CldUploadEventAction;
+  onRetryAction?: CldUploadEventAction;
+  onShowCompletedAction?: CldUploadEventAction;
+  onSourceChangedAction?: CldUploadEventAction;
+  onTagsAction?: CldUploadEventAction;
+  onUploadAddedAction?: CldUploadEventAction;
 }
 
 export type CldUploadWidgetPropsChildren = {
@@ -46,6 +59,7 @@ export type CldUploadWidgetPropsChildren = {
 } & CloudinaryUploadWidgetInstanceMethods;
 
 export type CldUploadEventCallback = (results: CloudinaryUploadWidgetResults, widget: CldUploadEventCallbackWidget) => void;
+export type CldUploadEventAction = (results: CloudinaryUploadWidgetResults) => void;
 export type CldUploadEventCallbackNoOptions = (results: CloudinaryUploadWidgetResults, widget: CldUploadWidgetWidgetInstance) => void;
 export type CldUploadEventCallbackWidgetOnly = (widget: CldUploadWidgetWidgetInstance) => void;
 export type CldUploadEventCallbackError = (error: CloudinaryUploadWidgetError, widget: CldUploadEventCallbackWidget) => void;

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -29,6 +29,7 @@ export interface CldUploadWidgetProps {
   onShowCompleted?: CldUploadEventCallback;
   onSourceChanged?: CldUploadEventCallback;
   onSuccess?: CldUploadEventCallback;
+  onSuccessAction?: (results: FormData) => void;
   onTags?: CldUploadEventCallback;
   onUploadAdded?: CldUploadEventCallback;
   options?: CloudinaryUploadWidgetOptions;

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -35,7 +35,6 @@ export interface CldUploadWidgetProps {
   signatureEndpoint?: URL | RequestInfo;
   uploadPreset?: string;
   onSuccessAction?: CldUploadEventAction;
-  onUploadAction?: CldUploadEventAction;
   onAbortAction?: CldUploadEventAction;
   onBatchCancelledAction?: CldUploadEventAction;
   onCloseAction?: CldUploadEventAction;


### PR DESCRIPTION
# Description
This PR adds an onSuccessAction prop to the CloudUploadWidget component.
<!-- Include a summary of the change made and also list the dependencies that are required if any -->

The feature makes a few changes to the `CloudUploadWidget` and `CloudUploadButton` components by adding a new `onSuccessAction` prop where a server action can be passed as a function to be called on the success of an image upload.



## Issue Ticket Number

Fixes #486 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/next-cloudinary/issues/<ISSUE_NUMBER> -->

Fixes: https://github.com/cloudinary-community/next-cloudinary/issues/486
## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ . ] This change requires a documentation update



