### PR TITLE
Captions & Subtitles, URL Default Version, TS Config Tweaks

### DIFF
--- a/docs/pages/cldvideoplayer/configuration.mdx
+++ b/docs/pages/cldvideoplayer/configuration.mdx
@@ -140,7 +140,7 @@ textTracks={{
       label: 'English',
       language: 'en',
       default: true,
-      url: 'https://res.cloudinary.com/demo/raw/upload/<FileName>.vtt'
+      url: 'https://res.cloudinary.com/<Cloud Name>/raw/upload/<FileName>.vtt'
     }
   }
 }}

--- a/docs/pages/cldvideoplayer/configuration.mdx
+++ b/docs/pages/cldvideoplayer/configuration.mdx
@@ -83,6 +83,7 @@ import Table from '../../components/Table';
 | publicId           | string         | -               | **Check Cloudinary Video Player Api Docs**      | **Check Cloudinary Video Api Docs** |
 | sourceTransformation  | object      | -               | **Check Cloudinary Video Player Api Docs**      | **Check Cloudinary Video Api Docs** |
 | sourceTypes        | array          | -               | Streaming format                         | `['hls']`                    |
+| textTracks         | object         | -               | Captions or subtitles for the active video| See Text Tracks below |
 | transformation     | object/array   | -               | Transformations to apply to the video    | `{ width: 200, height: 200, crop: 'fill' }` |
 
 ## Ads And Analytics Props
@@ -123,6 +124,32 @@ You can either specify a `src` option with a custom public ID or omit the `src`,
 ID to render an automatically generated preview image.
 
 [View examples](/cldvideoplayer/examples#poster).
+
+### Text Tracks
+
+The `textTracks` prop allows you to add captions or subtitles to the player.
+
+Each Text Track is an object containing details about where the captions or subtitles should
+be loaded from as well as any customization of that track.
+
+**Examples**
+
+```
+textTracks={{
+  captions: {
+      label: 'English',
+      language: 'en',
+      default: true,
+      url: 'https://res.cloudinary.com/demo/raw/upload/<FileName>.vtt'
+    }
+  }
+}}
+```
+
+Learn more on the [Video Player Reference](https://cloudinary.com/documentation/video_player_api_reference#text_tracks) or
+the [Subtitles and Captions guide](https://cloudinary.com/documentation/video_player_customization#subtitles_and_captions).
+
+
 ### Theme Colors
 
 The `colors` prop takes an object that can control what colors are used in the player:
@@ -144,7 +171,7 @@ You can add custom localization options to control the languages of the player p
 | language           | string        | -              | The language of the player's labels.     |
 | languages          | object        | -              | Language configuration and label overrides. |
 
-Uses Vide.js JSON format for localization customization: https://videojs.com/guides/languages/#json-format
+Uses Video.js JSON format for localization customization: https://videojs.com/guides/languages/#json-format
 
 ## Player APIs
 

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -16,8 +16,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@cloudinary-util/types": "1.5.3",
-    "@cloudinary-util/url-loader": "5.10.0",
+    "@cloudinary-util/types": "1.5.8",
+    "@cloudinary-util/url-loader": "5.10.3",
     "@cloudinary-util/util": "^3.3.2",
     "@tsconfig/recommended": "^1.0.7"
   },

--- a/next-cloudinary/src/lib/cloudinary.ts
+++ b/next-cloudinary/src/lib/cloudinary.ts
@@ -38,7 +38,7 @@ export async function pollForProcessingImage(options: PollForProcessingImageOpti
  * getCloudinaryConfig
  */
 
-export function getCloudinaryConfig(config?: ConfigOptions) {
+export function getCloudinaryConfig(config?: ConfigOptions): ConfigOptions {
   const cloudName = config?.cloud?.cloudName ?? process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
 
   if (!cloudName) {

--- a/next-cloudinary/tests/helpers/getCldImageUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldImageUrl.spec.js
@@ -26,7 +26,7 @@ describe('Cloudinary', () => {
         height: 100
       });
 
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/v1/turtle`);
     });
   });
 
@@ -46,7 +46,7 @@ describe('Cloudinary', () => {
         height: 100
       });
 
-      expect(url).toContain(`https://${secureDistrubtion}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+      expect(url).toContain(`https://${secureDistrubtion}/image/upload/c_limit,w_100/f_auto/q_auto/v1/turtle`);
     });
   });
 })

--- a/next-cloudinary/tests/helpers/getCldOgImageUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldOgImageUrl.spec.js
@@ -27,7 +27,7 @@ describe('Cloudinary', () => {
         src
       });
 
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_fill,w_${OG_IMAGE_WIDTH},h_${OG_IMAGE_HEIGHT},g_center/c_limit,w_${OG_IMAGE_WIDTH}/f_jpg/q_auto/${src}`);
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_fill,w_${OG_IMAGE_WIDTH},h_${OG_IMAGE_HEIGHT},g_center/c_limit,w_${OG_IMAGE_WIDTH}/f_jpg/q_auto/v1/${src}`);
     });
 
     it('should allow customization of width and height', () => {
@@ -45,7 +45,7 @@ describe('Cloudinary', () => {
         height
       });
 
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_fill,w_${width},h_${height},g_center/c_limit,w_${width}/f_jpg/q_auto/${src}`);
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_fill,w_${width},h_${height},g_center/c_limit,w_${width}/f_jpg/q_auto/v1/${src}`);
     });
   });
 })

--- a/next-cloudinary/tests/helpers/getCldVideoUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldVideoUrl.spec.js
@@ -26,7 +26,7 @@ describe('Cloudinary', () => {
         height: 100
       });
 
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/video/upload/c_limit,w_100/f_auto:video/q_auto/turtle`);
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/video/upload/c_limit,w_100/f_auto:video/q_auto/v1/turtle`);
     });
   });
 
@@ -46,7 +46,7 @@ describe('Cloudinary', () => {
         height: 100
       });
 
-      expect(url).toContain(`https://${secureDistrubtion}/video/upload/c_limit,w_100/f_auto:video/q_auto/turtle`);
+      expect(url).toContain(`https://${secureDistrubtion}/video/upload/c_limit,w_100/f_auto:video/q_auto/v1/turtle`);
     });
   });
 })

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -89,7 +89,7 @@ describe('Cloudinary Loader', () => {
 
       const result = cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldConfig });
 
-      expect(result).toContain('https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_960/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
+      expect(result).toContain('https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_960/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
     });
 
     it('should return responsive images', async () => {
@@ -106,15 +106,15 @@ describe('Cloudinary Loader', () => {
       // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
       const loaderOptions1 = { width: 2048 };
       const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions2 = { width: 3840 };
       const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions3 = { width: 640 };
       const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
 
     it('should add any resizing after any effects are added', async () => {
@@ -141,15 +141,15 @@ describe('Cloudinary Loader', () => {
 
       const loaderOptions1 = { width: 2048 };
       const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions1.width},h_${(loaderOptions1.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions1.width},h_${(loaderOptions1.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions2 = { width: 3840 };
       const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions2.width},h_${(loaderOptions2.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions2.width},h_${(loaderOptions2.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions3 = { width: 640 };
       const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions3.width},h_${(loaderOptions3.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_fill,w_${loaderOptions3.width},h_${(loaderOptions3.width / imageProps.width) * imageProps.height},g_auto/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
 
     it('should add two-stage resizing and cropping', async () => {
@@ -181,15 +181,15 @@ describe('Cloudinary Loader', () => {
 
       const loaderOptions1 = { width: 2048 };
       const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions2 = { width: 3840 };
       const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions3 = { width: 640 };
       const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_${cldOptions.crop.type},w_${cldOptions.crop.width},h_${cldOptions.crop.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/v1/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
 
     it('should add any resizing when fill is set to true without a width or height', async () => {

--- a/next-cloudinary/tsconfig.json
+++ b/next-cloudinary/tsconfig.json
@@ -3,11 +3,13 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "jsx": "react",
     "lib": ["dom", "esnext"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "noEmit": false,
     "resolveJsonModule": true,
     "sourceMap": true,
     "target": "esnext",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,11 +82,11 @@ importers:
   next-cloudinary:
     dependencies:
       '@cloudinary-util/types':
-        specifier: 1.5.3
-        version: 1.5.3
+        specifier: 1.5.8
+        version: 1.5.8
       '@cloudinary-util/url-loader':
-        specifier: 5.10.0
-        version: 5.10.0
+        specifier: 5.10.3
+        version: 5.10.3
       '@cloudinary-util/util':
         specifier: ^3.3.2
         version: 3.3.2
@@ -753,11 +753,11 @@ packages:
   '@cloudinary-util/types@1.4.0':
     resolution: {integrity: sha512-0zWtZ78IlIKS2xrdtPXHCYtLuAbxtlWpNTKb5CGP86wJUCm/r7e12v5xzjcx3tSzY6NlEsnxV88xhp64s834LA==}
 
-  '@cloudinary-util/types@1.5.3':
-    resolution: {integrity: sha512-/EbFhGKw942gAmBYN8iLCB8+7PfQR6DRIkfJWWoDf8OxInIrnVAhWHy+m1g1oltrTHZKbkF57oPJmi9Yv/4IIQ==}
+  '@cloudinary-util/types@1.5.8':
+    resolution: {integrity: sha512-gD6n1mPLvqQ/0GXx0DwXk6dud1X2ij/XGzX7uz+X3AObvCAEngdBXgStuz9O8PmnlAiQvhulvwwWZVXHvgpjJg==}
 
-  '@cloudinary-util/url-loader@5.10.0':
-    resolution: {integrity: sha512-FW2hkDpOQ9LgeecrID5NTx84Zfk7MSZXMy2W+sJ0g3R2SaXZyykqtcMluzX94CypPgsu1OoM8qPs3l1gKTwarQ==}
+  '@cloudinary-util/url-loader@5.10.3':
+    resolution: {integrity: sha512-bKALWnD2HHL/OZlIQECdjFrGvZYu9VG+RG9pne1y9OVhdClSNS3CZKKSf4F+htcYSp8JXpjdKUzTp2t21b6kiA==}
 
   '@cloudinary-util/url-loader@5.7.0':
     resolution: {integrity: sha512-Wt9yOeldVRMAFe1NOHG0fxXbGQ5ZP3f/zaH08PHS4nKVneeq5QWMi25sd9sn3QPwZ8CZ+0YGiQVArYhOY/EvAg==}
@@ -5322,11 +5322,11 @@ snapshots:
 
   '@cloudinary-util/types@1.4.0': {}
 
-  '@cloudinary-util/types@1.5.3': {}
+  '@cloudinary-util/types@1.5.8': {}
 
-  '@cloudinary-util/url-loader@5.10.0':
+  '@cloudinary-util/url-loader@5.10.3':
     dependencies:
-      '@cloudinary-util/types': 1.5.3
+      '@cloudinary-util/types': 1.5.8
       '@cloudinary-util/util': 3.3.2
       '@cloudinary/url-gen': 1.15.0
       zod: 3.22.4


### PR DESCRIPTION
# Description

Updates the TypeScript types to pull in `textTracks` to the CldVideoPlayer component, which opens up the ability to add captions and subtitles to videos.

This was technically already possible, as the option would be passed to the player, but the types may have prevented it.

Usage:

```
textTracks={{
  captions: {
      label: 'English',
      language: 'en',
      default: true,
      url: 'https://res.cloudinary.com/<Cloud Name>/raw/upload/<FileName>.vtt'
    }
  }
}}
```

This also pulls in changes to `getCldImageUrl` which adds a version number by default (v1). This is to improve the compatibility of `getCldImageUrl` with the parsing capabilities that require a version number.

Finally made a few TS config tweaks pulled over from: https://github.com/cloudinary-community/astro-cloudinary/pull/8

## Issue Ticket Number

Fixes #430 
Fixes #515 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
