### PR TITLE
fix: widget isn't destroyed on unmount

### DIFF
--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -137,7 +137,7 @@ const CldUploadWidget = ({
       widget.current?.destroy();
       widget.current = undefined;
     }
-  }, [])
+  }, [widget.current])
 
   /**
    * Instance Methods

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -36,6 +36,7 @@ const CldUploadWidget = ({
 }: CldUploadWidgetProps) => {
   const cloudinary: CldUploadWidgetCloudinaryInstance = useRef();
   const widget: CldUploadWidgetWidgetInstance = useRef();
+  const isMounted = useRef<boolean>();
 
   const [error, setError] = useState<CloudinaryUploadWidgetError | undefined>(undefined);
   const [results, setResults] = useState<CloudinaryUploadWidgetResults | undefined>(undefined);
@@ -116,6 +117,10 @@ const CldUploadWidget = ({
    */
 
   function handleOnLoad() {
+    if (!isMounted.current) {
+      return;
+    }
+
     setIsScriptLoading(false);
 
     if ( !cloudinary.current ) {
@@ -133,11 +138,16 @@ const CldUploadWidget = ({
   }
 
   useEffect(() => {
+    isMounted.current = true;
+  },[])
+  
+  useEffect(() => {
     return () => {
+      isMounted.current = false;
       widget.current?.destroy();
       widget.current = undefined;
     }
-  }, [widget.current])
+  }, [])
 
   /**
    * Instance Methods


### PR DESCRIPTION
# Description

Since the component is mounted, unmounted, and then mounted again, the onLoad event on the <Script /> component from next/script fires multiple times. As a result, two iframes are created instead of one.

I noticed that you implemented a useEffect() to remove the old widget, but it does not work as intended. Below, I will explain why it fails and provide possible solution.

Ensure useEffect() Executes Properly. Currently, the code contains the following useEffect() for cleanup:
```
useEffect(() => {
  return () => {
    widget.current?.destroy();
    widget.current = undefined;        
  }
}, [])
```
This should clean up the previous widget, but the issue is that it does not track updates to the widget.current variable. How to Fix It? 
Instead of using an empty dependency array [], update it to track widget.current:
```
useEffect(() => {
  return () => {
    widget.current?.destroy();
    widget.current = undefined;        
  }
}, [widget.current])
```
This ensures the cleanup runs correctly when widget.current changes, preventing multiple iframe creations.

## Issue Ticket Number

Fixes #587
(https://github.com/cloudinary-community/next-cloudinary/issues/587)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation (**I think it's unnecessary**)
