### PR TITLE
docs: remove Beta label from stable CldImage features

### DIFF
--- a/docs/pages/cldimage/configuration.mdx
+++ b/docs/pages/cldimage/configuration.mdx
@@ -167,7 +167,7 @@ right inside of Next.js.
       more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/transformation_reference#e_extract">More Info</a>)
     },
     {
-      prop: 'fillBackground (Beta)',
+      prop: 'fillBackground',
       type: 'boolean | object',
       default: '-',
       example: () => (<code>{`{{ gravity: 'east' }}`}</code>),
@@ -424,9 +424,6 @@ crop={{
 
 ### `enhance`
 
-<Callout emoji={false} type="info">
-  Generative Enhance is currently in beta.
-</Callout>
 
 Uses generative AI to enhance the visual appeal of an image.
 
@@ -443,11 +440,6 @@ enhance
 
 
 ### `extract`
-
-<Callout emoji={false} type="info">
-  Extract is currently in beta.
-</Callout>
-
 
 Extracts an area or multiple areas of an image, described in natural language, keeping
 the content of the extracted area (like background removal) or making the extracted area
@@ -533,9 +525,6 @@ extract={{
 
 ### `fillBackground`
 
-<Callout emoji={false} type="info">
-  Generative Fill is currently in beta.
-</Callout>
 
 Automatically fills the padded area using generative AI to extend the image seamlessly.
 
@@ -622,9 +611,6 @@ loop
 
 ### `recolor`
 
-<Callout emoji={false} type="info">
-  Generative Recolor is currently in beta.
-</Callout>
 
 Uses generative AI to recolor parts of your image, maintaining the relative shading.
 
@@ -686,10 +672,6 @@ recolor={{
 [Learn more about the Generative Recolor transformation](https://cloudinary.com/documentation/transformation_reference#e_gen_recolor) on the Cloudinary docs.
 
 ### `remove`
-
-<Callout emoji={false} type="info">
-  Generative Remove is currently in beta.
-</Callout>
 
 Uses generative AI to remove unwanted parts of your image, replacing the area with realistic pixels.
 
@@ -799,10 +781,6 @@ removeBackground
 
 ### `replace`
 
-<Callout emoji={false} type="info">
-  Generative Replace is currently in beta.
-</Callout>
-
 Uses generative AI to replace parts of your image with something else.
 
 The `replace` prop can either be an array with the objects to be replaced or an object
@@ -864,10 +842,6 @@ replace={{
 
 ### `replaceBackground`
 
-<Callout emoji={false} type="info">
-  Generative Replace Background is currently in beta.
-</Callout>
-
 Uses generative AI to replace the background of your image.
 
 The `replaceBackground` prop can be a boolean, string, or object
@@ -928,10 +902,6 @@ replaceBackground={{
 [Learn more about the Generative Replace Background transformation](https://cloudinary.com/documentation/transformation_reference#e_gen_background_replace) on the Cloudinary docs.
 
 ### `restore`
-
-<Callout emoji={false} type="info">
-  Generative Restore is currently in beta.
-</Callout>
 
 Uses generative AI to restore details in poor quality images or images that may have become degraded through repeated processing and compression.
 


### PR DESCRIPTION
# Description

Removed the "Beta" label from the enhance, fillBackground, recolor, remove, replace, replaceBackground, and restore features in the CldImage configuration docs.
These features are now stable on Cloudinary’s side and no longer require the Beta designation.

## Issue Ticket Number

Fixes #595 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/next-cloudinary/issues/<ISSUE_NUMBER> -->

**Before**
<img width="1075" height="237" alt="image" src="https://github.com/user-attachments/assets/bc917ec8-c448-48b6-93a2-fac6ed57c221" />
<img width="1077" height="170" alt="image" src="https://github.com/user-attachments/assets/f56f8bdf-0b9e-41d4-9734-31743ee32e06" />
<img width="1079" height="350" alt="image" src="https://github.com/user-attachments/assets/a6de68e6-0d84-4cb2-b668-0dba5ecfd8a0" />


**After**

<img width="1082" height="717" alt="image" src="https://github.com/user-attachments/assets/1f8fcd1c-86c7-4870-aca4-f4813db383d7" />
<img width="1070" height="240" alt="image" src="https://github.com/user-attachments/assets/311c031e-7bae-4a9e-ac48-67f91495d9da" />


## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
