### PR TITLE
fix: resolve CldVideoPlayer fullscreen object-cover issue #433

### DIFF
--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -127,7 +127,7 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
       <Head>
         <link href={`https://unpkg.com/cloudinary-video-player@${PLAYER_VERSION}/dist/cld-video-player.min.css`} rel="stylesheet" />
       </Head>
-      <div style={{ width: '100%', aspectRatio: `${width} / ${height}`}}>
+      <div style={{ width: '100%' }}>
         <video
           ref={videoRef}
           id={playerId}


### PR DESCRIPTION
fixes #433.

## Description

Fixes the full-screen object-cover issue with CldVideoPlayer, where videos wouldn't properly fill the screen in full-screen mode. The wrapper div's `aspectRatio` constraint was interfering with VideoJS's fullscreen implementation, preventing videos from scaling correctly while poster images worked as expected.

**Root Cause:** VideoJS handles aspect ratios internally through its own classes and styling system. The wrapper div's `aspectRatio` CSS property was creating a constraint conflict when VideoJS attempted to move the video element to fullscreen (`position: fixed`).

**Solution:** Removed the redundant `aspectRatio` property from the wrapper div styling in `CldVideoPlayer.tsx`, allowing VideoJS's built-in fullscreen mechanism to work without constraint interference.

## Issue Ticket Number

Fixes #433

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation

## Files Changed
- `next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx` - Removed aspectRatio constraint from wrapper div