### PR TITLE
Added support for auto_Pad crop mode

### DIFF
--- a/next-cloudinary/src/helpers/getCldImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldImageUrl.ts
@@ -12,8 +12,35 @@ export type GetCldImageUrlConfig = ConfigOptions;
 export type GetCldImageUrlAnalytics = AnalyticsOptions;
 
 export function getCldImageUrl(options: GetCldImageUrlOptions, config?: GetCldImageUrlConfig, analytics?: GetCldImageUrlAnalytics) {
+  let modifiedOptions = { ...options };
+  
+  const isAutoPad = String(modifiedOptions.crop) === 'auto_pad';
+  
+  if (isAutoPad) {
+    const existingRawTransformations = modifiedOptions.rawTransformations || [];
+    const rawTransformations = Array.isArray(existingRawTransformations) 
+      ? [...existingRawTransformations] 
+      : [existingRawTransformations];
+    
+    if (String(modifiedOptions.gravity) === 'auto') {
+      const { gravity, ...optionsWithoutGravity } = modifiedOptions;
+      modifiedOptions = optionsWithoutGravity;
+      rawTransformations.push('g_auto');
+    }
+    
+    if (modifiedOptions.aspectRatio) {
+      const { aspectRatio, ...optionsWithoutAspectRatio } = modifiedOptions;
+      modifiedOptions = optionsWithoutAspectRatio;
+      rawTransformations.push(`ar_${aspectRatio}`);
+    }
+    
+    if (rawTransformations.length > 0) {
+      modifiedOptions.rawTransformations = rawTransformations;
+    }
+  }
+  
   return constructCloudinaryUrl({
-    options,
+    options: modifiedOptions,
     config: getCloudinaryConfig(config),
     analytics: getCloudinaryAnalytics(analytics)
   });

--- a/next-cloudinary/tests/helpers/getCldImageUrl.spec.js
+++ b/next-cloudinary/tests/helpers/getCldImageUrl.spec.js
@@ -28,6 +28,44 @@ describe('Cloudinary', () => {
 
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/v1/turtle`);
     });
+
+    it('should support auto_pad crop mode with auto gravity', () => {
+      const cloudName = 'customtestcloud';
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+
+      const url = getCldImageUrl({
+        src: 'turtle',
+        width: 960,
+        aspectRatio: '16:9',
+        crop: 'auto_pad',
+        gravity: 'auto'
+      });
+
+      expect(url).toContain('c_auto_pad');
+      expect(url).toContain('g_auto');
+      expect(url).toContain('ar_16:9');
+      expect(url).toContain('w_960');
+    });
+
+    it('should support auto_pad crop mode with width and height', () => {
+      const cloudName = 'customtestcloud';
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+
+      const url = getCldImageUrl({
+        src: 'turtle',
+        width: 960,
+        height: 540,
+        crop: 'auto_pad',
+        gravity: 'auto'
+      });
+
+      expect(url).toContain('c_auto_pad');
+      expect(url).toContain('g_auto');
+      expect(url).toContain('w_960');
+      expect(url).toContain('h_540');
+    });
   });
 
   describe('Config', () => {


### PR DESCRIPTION
# Description
Implemented full support for the auto_pad crop mode in getCldImageUrl, ensuring correct inclusion of g_auto and ar_ parameters.

## Issue Ticket Number

Fixes #592 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
