### PR TITLE
e replce with error

### DIFF
--- a/docs/pages/api/sign-cloudinary-params.js
+++ b/docs/pages/api/sign-cloudinary-params.js
@@ -13,7 +13,7 @@ export default async function handler(req, res) {
     });
   } catch (error) {
     res.status(500).json({
-      error: e.message,
+      error: error.message,
     });
   }
 }


### PR DESCRIPTION
# **Bug Report**

## **Describe the bug**
In the Cloudinary API signature handler file, there is a variable mismatch inside the catch block. The catch clause defines the error variable as error, but inside the block, it references e.message instead of error.message. This causes a ReferenceError when the code tries to handle an exception.

```
ReferenceError: e is not defined

```

/pages/api/signature.js (or wherever this handler file is located)


## **Steps To Reproduce the error**

💡 Steps to Reproduce

1. Trigger any condition that causes the try block to fail (for example, invalid Cloudinary credentials).

2. Observe that instead of returning a proper error response, the server crashes or returns a 500 error with the message e is not defined.


🛠️ Proposed Fix

Replace:
```
catch (error) {
  res.status(500).json({
    error: e.message,
  });
}
```
with:
```
catch (error) {
  res.status(500).json({
    error: error.message,
  });
}
```