### PR TITLE
🐛 Fix: Undefined Variable Reference in Error Handler

### DIFF
--- a/docs/pages/api/sign-cloudinary-params.js
+++ b/docs/pages/api/sign-cloudinary-params.js
@@ -13,7 +13,7 @@ export default async function handler(req, res) {
     });
   } catch (error) {
     res.status(500).json({
-      error: e.message,
+      error: error.message,
     });
   }
 }


### PR DESCRIPTION
## Issue

The error handler in `docs/pages/api/sign-cloudinary-params.js` references an undefined variable `e` instead of the correctly scoped `error` variable, causing a `ReferenceError` when errors occur.

## Bug Details

**File:** `docs/pages/api/sign-cloudinary-params.js:16`  
**Severity:** Low  
**Type:** Runtime Error

The catch block defines the error parameter as `error`, but the code references `e.message`:

```javascript
} catch (error) {  // ✅ Parameter named 'error'
  res.status(500).json({
    error: e.message,  // ❌ References 'e' (undefined)
  });
}
```

## Impact

- When signature generation fails, the server throws an additional `ReferenceError: e is not defined`
- Clients receive incomplete responses or timeouts instead of proper error messages
- The original error is obscured, making debugging difficult

## Fix

Changed `e.message` to `error.message` to match the catch parameter:

```javascript
} catch (error) {
  res.status(500).json({
    error: error.message,  // ✅ Correct variable reference
  });
}
```

## Testing

- ✅ Code compiles without errors
- ✅ Variable reference is now consistent
- ✅ Error handler will work correctly when exceptions occur

## Hacktoberfest 2025

This contribution is part of Hacktoberfest 2025.

---

**Checklist:**
- [x] Bug fix for undefined variable
- [x] Simple, focused change
- [x] Clear commit message