### PR TITLE
🔒 Security: Replace Math.random() with React useId() for Component IDs

### DIFF
--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useId } from 'react';
 import Script from 'next/script';
 import { generateSignatureCallback, generateUploadWidgetResultCallback, getUploadWidgetOptions, UPLOAD_WIDGET_EVENTS } from '@cloudinary-util/url-loader'
 import {
@@ -40,6 +40,8 @@ const CldUploadWidget = ({
   const [error, setError] = useState<CloudinaryUploadWidgetError | undefined>(undefined);
   const [results, setResults] = useState<CloudinaryUploadWidgetResults | undefined>(undefined);
   const [isScriptLoading, setIsScriptLoading] = useState(true);
+  
+  const uniqueId = useId();
 
   // When creating a signed upload, you need to provide both your Cloudinary API Key
   // as well as a signature generator function that will sign any paramters
@@ -239,7 +241,7 @@ const CldUploadWidget = ({
         ...instanceMethods,
       })}
       <Script
-        id={`cloudinary-uploadwidget-${Math.floor(Math.random() * 100)}`}
+        id={`cloudinary-uploadwidget-${uniqueId.replace(/:/g, '')}`}
         src="https://upload-widget.cloudinary.com/global/all.js"
         onLoad={handleOnLoad}
         onError={(e) => console.error(`Failed to load Cloudinary Upload Widget: ${e.message}`)}


### PR DESCRIPTION
## Issue

The `CldUploadWidget` component uses `Math.random() * 100` to generate Script element IDs, which creates only 100 possible values and leads to frequent ID collisions.

## Security & Reliability Concerns

**File:** `next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx:244`  
**Severity:** Low  
**Type:** Security & Code Quality

### Problems with current implementation:

```javascript
<Script
  id={`cloudinary-uploadwidget-${Math.floor(Math.random() * 100)}`}
  ...
/>
```

- **Limited entropy:** Only 100 possible ID values (0-99)
- **High collision probability:** Multiple widgets on same page likely share IDs
- **Predictable IDs:** Could enable targeted DOM manipulation
- **Inconsistent pattern:** CldVideoPlayer already uses `useId()` (line 49)

### Impact:

- Script load events may not fire correctly due to ID collisions
- Multiple upload widgets may interfere with each other
- Unpredictable behavior when rendering multiple instances

## Solution

Replace `Math.random()` with React's built-in `useId()` hook:

```javascript
const uniqueId = useId();

<Script
  id={`cloudinary-uploadwidget-${uniqueId.replace(/:/g, '')}`}
  ...
/>
```

### Benefits:

- ✅ Guaranteed unique IDs across component tree
- ✅ Stable IDs that don't change between renders
- ✅ Zero collision risk even with many instances
- ✅ Follows React best practices
- ✅ Consistent with existing `CldVideoPlayer` implementation

## Testing

- ✅ TypeScript compilation passes
- ✅ No linter errors
- ✅ Pattern matches CldVideoPlayer component
- ✅ useId() is available in React 18+ (peer dependency)

## References

- [React useId() Documentation](https://react.dev/reference/react/useId)
- [CldVideoPlayer.tsx implementation](https://github.com/cloudinary-community/next-cloudinary/blob/main/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx#L49)

## Hacktoberfest 2025

This contribution is part of Hacktoberfest 2025.

---

**Checklist:**
- [x] Replaced Math.random() with useId()
- [x] Added useId to React imports
- [x] Consistent with existing patterns
- [x] No breaking changes