### PR TITLE
Fix :TypeScript import, OG metadata, use client, and placeholders in N…

### DIFF
--- a/docs/pages/nextjs-14.mdx
+++ b/docs/pages/nextjs-14.mdx
@@ -40,7 +40,7 @@ To avoid marking an entire page as a Client Component, you can create a basic wr
 ```jsx copy showLineNumbers
 "use client";
 
-import { CldImage as CldImageDefault, CldImageProps }  from 'next-cloudinary';
+import { CldImage as CldImageDefault, type CldImageProps } from 'next-cloudinary';
 
 const CldImage = (props: CldImageProps) => {
   return <CldImageDefault {...props} />
@@ -67,9 +67,13 @@ import { getCldOgImageUrl } from 'next-cloudinary';
 export const metadata = {
   openGraph: {
     ...
-    images: getCldOgImageUrl({
-      src: '<Public ID>'
-    })
+    images: [
+      {
+        url: getCldOgImageUrl({
+          src: 'your-public-id',
+        }),
+      },
+    ],
   },
 };
 ```


### PR DESCRIPTION
PR Title:
Fix TypeScript import, OG metadata, "use client", and placeholders in Next.js 13/14 docs (#611)

PR Description:
This PR addresses issue [#611](https://github.com/cloudinary-community/next-cloudinary/issues/611)
 by fixing multiple documentation/code problems in the Next.js 13/14 App Router examples:

Changes included:

TypeScript import fix: Added type before CldImageProps to prevent runtime errors in JS environments.

OG image metadata fix: Wrapped getCldOgImageUrl() in an array of objects with { url } for valid Next.js Open Graph configuration.

"use client" placement fix: Ensured "use client"; is the very first line in Client Component examples.

Placeholder fix: Replaced <Public ID> with 'your-public-id' to avoid confusion with JSX syntax.

These changes improve documentation clarity and correctness, making it easier for developers to integrate Next Cloudinary with Next.js 13/14 App Router