### PR TITLE
updated the footer with © Cloudinary 2025

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -14,7 +14,7 @@ export default {
     }
   },
   footer: {
-    text: `MIT ${new Date().getFullYear()} © Colby Fayock`,
+    text: `© Cloudinary ${new Date().getFullYear()}`,
   },
   editLink: {
     text: 'Edit this page on GitHub'


### PR DESCRIPTION
# Description

I have updated the footer of the website with © Cloudinary 2025 and made sure to not hard code the year value.

## Issue Ticket Number

Fixes #631

## Type of change

<!-- Please select all options that are applicable. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ X] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [ X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [ X] I have performed a self-review of my own code
- [ X] I have run tests locally to ensure they all pass
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes needed to the documentation
