### PR TITLE
fix(docs): use Tailwind italic for HeaderImage caption

### DIFF
--- a/docs/components/HeaderImage/HeaderImage.js
+++ b/docs/components/HeaderImage/HeaderImage.js
@@ -7,7 +7,7 @@ export const HeaderImage = ({ children, layout, caption }) => {
         { children }
       </div>
       {caption && (
-        <p className="mt-4 !-mb-3 text-sm text-center italics">{ caption }</p>
+        <p className="mt-4 !-mb-3 text-sm text-center italic">{ caption }</p>
       )}
     </div>
   );


### PR DESCRIPTION
# Description

Fix caption styling in the docs `HeaderImage` component by replacing the incorrect Tailwind class `italics` with `italic` so captions render as intended.

- Affected component: `next-cloudinary/docs/components/HeaderImage/HeaderImage.js`
- Visible on: `/cldimage/examples` → “Extract” section (caption: “Prompt: dogs; Multiple: true”)


| Before (not italic) | After (italic) |
| --- | --- |
| <img width="1553" height="575" alt="before" src="https://github.com/user-attachments/assets/1df79739-0e6f-4954-9e1c-d07210af5d6f" /> | <img width="1567" height="588" alt="after" src="https://github.com/user-attachments/assets/cfe174a1-4e27-4c5f-bf04-a3cb32470b30" /> |


Code change (before → after)

```diff
--- a/next-cloudinary/docs/components/HeaderImage/HeaderImage.js
+++ b/next-cloudinary/docs/components/HeaderImage/HeaderImage.js
@@ -7,7 +7,7 @@ export const HeaderImage = ({ children, layout, caption }) => {
       </div>
       {caption && (
-        <p className="mt-4 !-mb-3 text-sm text-center italics">{ caption }</p>
+        <p className="mt-4 !-mb-3 text-sm text-center italic">{ caption }</p>
       )}
     </div>
   );
```

No new dependencies.

## Issue Ticket Number

Fixes #638

<!-- Example: Fixes https://github.com/cloudinary-community/next-cloudinary/issues/638 -->

## Type of change

- [x] Fix or improve the documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation