### PR TITLE
fix(docs): enable muted autoplay for YouTube video in “Watch & Learn

### DIFF
--- a/docs/components/Video/Video.js
+++ b/docs/components/Video/Video.js
@@ -54,14 +54,14 @@ export const Video = ({
           }}
         >
           <iframe
-          title={title}
-          width={width}
-          height={height}
-          src={`https://www.youtube.com/embed/${videoId}?feature=oembed`}
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-        />
+            title={title}
+            width={width}
+            height={height}
+            src={`https://www.youtube.com/embed/${videoId}?feature=oembed`}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
         </div>
       ) : (
         <div


### PR DESCRIPTION
# Description

Enable muted autoplay for the YouTube video in the docs “Watch & Learn” section to improve UX. Autoplay is requested via YouTube URL params (required by modern browser policies), and the redundant `autoPlay` attribute is removed.

- Affected file: `next-cloudinary/docs/components/Video/Video.js`
- Affected page: `/cldimage/basic-usage` → “Watch & Learn”

Before vs After

| Before (no autoplay) | After (muted autoplay) |
| --- | --- |
| Video becomes visible but doesn’t start | Video begins playing muted when visible |

Code change

```diff
--- a/next-cloudinary/docs/components/Video/Video.js
+++ b/next-cloudinary/docs/components/Video/Video.js
@@ -56,13 +56,12 @@ export const Video = ({
         >
           <iframe
             title={title}
             width={width}
             height={height}
-            src={`https://www.youtube.com/embed/${videoId}?feature=oembed`}
+            src={`https://www.youtube.com/embed/${videoId}?feature=oembed&autoplay=1&mute=1&playsinline=1`}
             frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
-            autoPlay
           />
         </div>
       ) : (
```

No new dependencies.

## Issue Ticket Number

Fixes #640 
## Type of change

- [x] Fix or improve the documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation